### PR TITLE
Added patch for DIA SDK path issue on win-64

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,6 +3,8 @@ c_compiler:         # [osx]
 cxx_compiler:       # [osx]
   - clang_bootstrap # [osx]
 
-cxx_compiler_version: # [linux and ppc64le]
+cxx_compiler_version: # [linux]
+  - 10                # [linux and aarch64]
+  - 9                 # [linux and not ppc64le and not aarch64]
   # linking error with gcc 9
   - 8                 # [linux and ppc64le]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,8 +3,6 @@ c_compiler:         # [osx]
 cxx_compiler:       # [osx]
   - clang_bootstrap # [osx]
 
-cxx_compiler_version: # [linux]
-  - 10                # [linux and aarch64]
-  - 9                 # [linux and not ppc64le and not aarch64]
-  # linking error with gcc 9
+cxx_compiler_version: # [linux and ppc64le]
+  # linking error with gcc 9+ (relocation truncated to fit: R_PPC64_REL24 against symbol ...)
   - 8                 # [linux and ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -184,15 +184,14 @@ outputs:
 
   - name: lit
     build:
-      noarch: python
       script: python -m pip install utils/lit --no-deps -vv
       activate_in_script: true
-      skip: true  # [not linux]
+      skip: true  # [py<30]
       entry_points:
         - lit = lit:main
     requirements:
       host:
-        - python >=3
+        - python
         - pip
         - setuptools
         - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ source:
     - patches/xfail-permission-test-on-linux.patch  # [unix]
     - patches/skip-osx-getMacOSHostVersion.patch  # [osx]
     - patches/MSVC_DIA_SDK_path_fix.diff  # [win]
+    - patches/benchmark_register_include_fix.diff
 
 build:
   number: {{ build_number }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set ccache_method = 'native' %}  # [unix]
 {% set ccache_method = 'symlinks' %}  # [win]
 
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set major_ver = version.split(".")[0] %}
 
 {% set posix = 'm2-' if win else '' %}
@@ -29,6 +29,7 @@ source:
     # - patches/llvm-config-no-libLLVM.diff
     - patches/xfail-permission-test-on-linux.patch  # [unix]
     - patches/skip-osx-getMacOSHostVersion.patch  # [osx]
+    - patches/MSVC_DIA_SDK_path_fix.diff  # [win]
 
 build:
   number: {{ build_number }}
@@ -201,7 +202,8 @@ outputs:
         - lit
 
 about:
-  home: http://llvm.org/
+  home: https://llvm.org/
+  doc_url: https://llvm.org/docs/
   dev_url: https://github.com/llvm-mirror/llvm
   license: Apache-2.0 WITH LLVM-exception
   license_file: LICENSE.TXT

--- a/recipe/patches/MSVC_DIA_SDK_path_fix.diff
+++ b/recipe/patches/MSVC_DIA_SDK_path_fix.diff
@@ -1,0 +1,70 @@
+The previous method for including the DIA SDK caused an absolute
+path to be included in LLVMDebugInfoPDB's INTERFACE_LINK_LIBRARIES
+when the LLVMExports.cmake file was generated.
+This is problematic, as the path was machine-specific,
+and therefore may not exist, even if the DIA SDK is available.
+
+diff --git a/llvm/cmake/modules/AddDIA.cmake b/llvm/cmake/modules/AddDIA.cmake
+new file mode 100644
+index 000000000000..261b68a4c31d
+--- /dev/null
++++ b/llvm/cmake/modules/AddDIA.cmake
+@@ -0,0 +1,17 @@
++# Allows LLVMDebugInfoPDB to import the DIA SDK as a library target.
++
++if(NOT MSVC_DIA_SDK_DIR)
++    set(MSVC_DIA_SDK_DIR "$ENV{VSINSTALLDIR}DIA SDK")
++endif()
++
++set(MSVC_DIA_SDK_LINK_DIR "${MSVC_DIA_SDK_DIR}\\lib")
++if (CMAKE_SIZEOF_VOID_P EQUAL 8)
++    set(MSVC_DIA_SDK_LINK_DIR "${MSVC_DIA_SDK_LINK_DIR}\\amd64")
++endif()
++
++include_directories("${MSVC_DIA_SDK_DIR}\\include")
++
++add_library(MSVC_diaguids STATIC IMPORTED)
++set_target_properties(MSVC_diaguids PROPERTIES
++    IMPORTED_LOCATION "${MSVC_DIA_SDK_LINK_DIR}\\diaguids.lib"
++)
+diff --git a/llvm/cmake/modules/LLVMConfig.cmake.in b/llvm/cmake/modules/LLVMConfig.cmake.in
+index 4d8e33711d27..73bb7200f29b 100644
+--- a/llvm/cmake/modules/LLVMConfig.cmake.in
++++ b/llvm/cmake/modules/LLVMConfig.cmake.in
+@@ -99,6 +99,10 @@ set(LLVM_HAVE_OPT_VIEWER_MODULES @LLVM_HAVE_OPT_VIEWER_MODULES@)
+ set(LLVM_CONFIGURATION_TYPES @CMAKE_CONFIGURATION_TYPES@)
+ set(LLVM_ENABLE_SHARED_LIBS @BUILD_SHARED_LIBS@)
+ 
++if(LLVM_ENABLE_DIA_SDK)
++  include("${LLVM_CMAKE_DIR}/AddDIA.cmake")
++endif()
++
+ if(NOT TARGET LLVMSupport)
+   set(LLVM_EXPORTED_TARGETS "@LLVM_CONFIG_EXPORTS@")
+   include("@LLVM_CONFIG_EXPORTS_FILE@")
+diff --git a/llvm/lib/DebugInfo/PDB/CMakeLists.txt b/llvm/lib/DebugInfo/PDB/CMakeLists.txt
+index 9088bc86f668..fd7523e91bb5 100644
+--- a/llvm/lib/DebugInfo/PDB/CMakeLists.txt
++++ b/llvm/lib/DebugInfo/PDB/CMakeLists.txt
+@@ -4,12 +4,7 @@ macro(add_pdb_impl_folder group)
+ endmacro()
+ 
+ if(LLVM_ENABLE_DIA_SDK)
+-  include_directories(${MSVC_DIA_SDK_DIR}/include)
+-  set(LIBPDB_LINK_FOLDERS "${MSVC_DIA_SDK_DIR}\\lib")
+-  if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+-    set(LIBPDB_LINK_FOLDERS "${LIBPDB_LINK_FOLDERS}\\amd64")
+-  endif()
+-  file(TO_CMAKE_PATH "${LIBPDB_LINK_FOLDERS}\\diaguids.lib" LIBPDB_ADDITIONAL_LIBRARIES)
++  include(AddDIA)
+ 
+   add_pdb_impl_folder(DIA
+     DIA/DIADataStream.cpp
+@@ -136,4 +131,6 @@ add_llvm_component_library(LLVMDebugInfoPDB
+   ${LIBPDB_ADDITIONAL_HEADER_DIRS}
+   )
+ 
+-target_link_libraries(LLVMDebugInfoPDB INTERFACE "${LIBPDB_ADDITIONAL_LIBRARIES}")
++if(LLVM_ENABLE_DIA_SDK)
++  target_link_libraries(LLVMDebugInfoPDB INTERFACE MSVC_diaguids)
++endif()

--- a/recipe/patches/benchmark_register_include_fix.diff
+++ b/recipe/patches/benchmark_register_include_fix.diff
@@ -1,0 +1,14 @@
+<limits> must be explicitly included when compiling with with gcc 11.
+
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..4caa5ad4da07 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"


### PR DESCRIPTION
## Changes
Fixed DIA SDK dependency issue for `win-64`.
Updated `home` and `doc_url`.
Updated `cxx_compiler_version` for Linux architectures in `cbc`.
Added patch to include missing header in benchmark_register.h 
Removed `noarch` for `lit`

## Notes

The previous method for including the DIA SDK caused an absolute path to be included in `LLVMDebugInfoPDB`'s `INTERFACE_LINK_LIBRARIES` when the `LLVMExports.cmake` file was generated.

This is problematic, as the path was machine-specific and therefore may not exist, even if the DIA SDK is available. The location of the DIA SDK on Concourse and Prefect differs, which is what exposed this issue in the package.

This issue prevents `llvmlite` from being built on both Prefect and the `win-64` dev instances.