### PR TITLE
Bump build number to 5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set ccache_method = 'native' %}  # [unix]
 {% set ccache_method = 'symlinks' %}  # [win]
 
-{% set build_number = 2 %}
+{% set build_number = 5 %}
 {% set major_ver = version.split(".")[0] %}
 
 {% set posix = 'm2-' if win else '' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -204,7 +204,7 @@ outputs:
 about:
   home: https://llvm.org/
   doc_url: https://llvm.org/docs/
-  dev_url: https://github.com/llvm-mirror/llvm
+  dev_url: https://github.com/llvm/llvm-project/
   license: Apache-2.0 WITH LLVM-exception
   license_file: LICENSE.TXT
   license_family: Apache


### PR DESCRIPTION
## Changes
Build number bumped to `5` for `11.1.0`.

## Notes

This change is to ensure that the latest build of the package (including the following changes: [Add DIA SDK patch](https://github.com/AnacondaRecipes/llvmdev-feedstock/pull/6)) is available for all architectures. It was discovered that a previous older build of `11.1.0` for `osx-arm64` used the build number of `4` instead of `1`.
