### PR TITLE
patch RuntimeDyldELF

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,5 @@
 channels:
  dp_test: libxml2_buildout
 build_parameters:
-  - "--skip-existing"
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,4 @@
 channels:
  dp_test: libxml2_buildout
 build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
+  - "--skip-existing"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,5 @@
-# the conda-build parameters to use for disabling --skip-existing
+channels:
+ dp_test: libxml2_buildout
 build_parameters:
-  - ""
-
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,4 @@
-channels:
- dp_test: libxml2_buildout
+# the conda-build parameters to use for disabling --skip-existing
 build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
+  - ""
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - m2-git      # [win]
   host:
     - libcxx {{ cxx_compiler_version }}  # [osx]
-    - zlib
+    - zlib 1.2.13
     - libxml2 2.10 # [win]
     - libffi 3.4   # [unix]
 
@@ -63,7 +63,7 @@ outputs:
       host:
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools", exact=True) }}
-        - zlib
+        - zlib 1.2.13
       run:
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools", exact=True) }}
@@ -94,7 +94,7 @@ outputs:
         - python >=3             # [not win]
       host:
         - libcxx >={{ cxx_compiler_version }}  # [osx]
-        - zlib
+        - zlib 1.2.13
         - libffi 3.4  # [unix]
       run:
         - libcxx >={{ cxx_compiler_version }}  # [osx]
@@ -115,7 +115,7 @@ outputs:
       build:
       host:
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}  # [not win]
-        - zlib
+        - zlib 1.2.13
       run:   # [not win]
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}  # [not win]
       run_constrained:             # [not win]
@@ -140,7 +140,7 @@ outputs:
       host:
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
         - libxml2 2.10  # [win]
-        - zlib
+        - zlib 1.2.13
       run:
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
       run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,10 @@ source:
     # https://reviews.llvm.org/D101972
     - patches/osx_ver.patch
     - patches/MSVC_DIA_SDK_path_fix.diff  # [win]
+    - patches/llvm14-clear-gotoffsetmap.patch
 
 build:
-  number: 1
+  number: 2
   merge_build_host: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - patches/llvm14-clear-gotoffsetmap.patch
 
 build:
-  number: 2
+  number: 3
   merge_build_host: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
   host:
     - libcxx {{ cxx_compiler_version }}  # [osx]
     - zlib
-    - libxml2      # [win]
+    - libxml2 2.10 # [win]
     - libffi 3.4   # [unix]
 
 outputs:
@@ -139,7 +139,7 @@ outputs:
         - python >=3
       host:
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
-        - libxml2   # [win]
+        - libxml2 2.10  # [win]
         - zlib
       run:
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}

--- a/recipe/patches/llvm14-clear-gotoffsetmap.patch
+++ b/recipe/patches/llvm14-clear-gotoffsetmap.patch
@@ -1,0 +1,31 @@
+From 322c79fff224389b4df9f24ac22965867007c2fa Mon Sep 17 00:00:00 2001
+From: Graham Markall <gmarkall@nvidia.com>
+Date: Mon, 13 Mar 2023 21:35:11 +0000
+Subject: [PATCH] RuntimeDyldELF: Clear the GOTOffsetMap when finalizing the
+ load
+
+This needs resetting so that stale entries are not left behind when the
+GOT section and index are reset.
+
+See llvm/llvm#61402: RuntimeDyldELF doesn't clear GOTOffsetMap in
+finalizeLoad(), leading to invalid GOT relocations on AArch64 -
+https://github.com/llvm/llvm-project/issues/61402.
+---
+ llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+index f92618afdff6..eb3c27a9406a 100644
+--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
++++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+@@ -2345,6 +2345,7 @@ Error RuntimeDyldELF::finalizeLoad(const ObjectFile &Obj,
+     }
+   }
+ 
++  GOTOffsetMap.clear();
+   GOTSectionID = 0;
+   CurrentGOTIndex = 0;
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
patch  llvmdev for llvmlite 0.40.0 
- fix problem on aarch64
- see, https://github.com/numba/llvmlite/blob/v0.40.0/CHANGE_LOG#L8, https://github.com/numba/llvmlite/pull/926