### PR TITLE
LLVM19 Update for linux-64

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,9 +3,3 @@
 # before crashing.
 extra_labels_for_os:
   osx-arm64: [ventura]
-
-upload_without_merge: True
-
-upload_to_staging_channel_in_pr: False
-
-channels: [cuda12_def]

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,9 @@
 # before crashing.
 extra_labels_for_os:
   osx-arm64: [ventura]
+
+upload_without_merge: True
+
+upload_to_staging_channel_in_pr: False
+
+channels: [cuda12_def]

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,10 +8,9 @@ sed -i.bak "s/NOT APPLE AND NOT ARG_SONAME/NOT ARG_SONAME/g" llvm/cmake/modules/
 mkdir build
 cd build
 
-# TODO: TEMPORARILY DISABLING FOR TESTING PURPOSES
-# if [[ "$target_platform" == "linux-64" ]]; then
-#   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_USE_INTEL_JITEVENTS=ON"
-# fi
+if [[ "$target_platform" == "linux-64" ]]; then
+  CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_USE_INTEL_JITEVENTS=ON"
+fi
 
 if [[ "$CC_FOR_BUILD" != "" && "$CC_FOR_BUILD" != "$CC" ]]; then
   NATIVE_FLAGS="-DCMAKE_C_COMPILER=$CC_FOR_BUILD;-DCMAKE_CXX_COMPILER=$CXX_FOR_BUILD;-DCMAKE_C_FLAGS=-O2;-DCMAKE_CXX_FLAGS=-O2"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -62,6 +62,7 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DLLVM_BUILD_LLVM_DYLIB=yes \
       -DLLVM_LINK_LLVM_DYLIB=yes \
       -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly \
+      -DLLVM_ENABLE_FFI=ON \
       ${CMAKE_ARGS} \
       -GNinja \
       ../llvm

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,5 @@
-set -x
+#!/bin/bash
+set -exuo pipefail
 
 # Make osx work like linux.
 sed -i.bak "s/NOT APPLE AND ARG_SONAME/ARG_SONAME/g" llvm/cmake/modules/AddLLVM.cmake
@@ -7,28 +8,34 @@ sed -i.bak "s/NOT APPLE AND NOT ARG_SONAME/NOT ARG_SONAME/g" llvm/cmake/modules/
 mkdir build
 cd build
 
-export CPU_COUNT=4
-
 if [[ "$target_platform" == "linux-64" ]]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_USE_INTEL_JITEVENTS=ON"
 fi
 
 if [[ "$CC_FOR_BUILD" != "" && "$CC_FOR_BUILD" != "$CC" ]]; then
-  CMAKE_ARGS="${CMAKE_ARGS} -DCROSS_TOOLCHAIN_FLAGS_NATIVE=-DCMAKE_C_COMPILER=$CC_FOR_BUILD;-DCMAKE_CXX_COMPILER=$CXX_FOR_BUILD;-DCMAKE_C_FLAGS=-O2;-DCMAKE_CXX_FLAGS=-O2;-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,${BUILD_PREFIX}/lib;-DCMAKE_MODULE_LINKER_FLAGS=;-DCMAKE_SHARED_LINKER_FLAGS=;-DCMAKE_STATIC_LINKER_FLAGS=;-DLLVM_INCLUDE_BENCHMARKS=OFF;"
-  CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_HOST_TRIPLE=$(echo $HOST | sed s/conda/unknown/g) -DLLVM_DEFAULT_TARGET_TRIPLE=$(echo $HOST | sed s/conda/unknown/g)"
+  NATIVE_FLAGS="-DCMAKE_C_COMPILER=$CC_FOR_BUILD;-DCMAKE_CXX_COMPILER=$CXX_FOR_BUILD;-DCMAKE_C_FLAGS=-O2;-DCMAKE_CXX_FLAGS=-O2"
+  NATIVE_FLAGS="${NATIVE_FLAGS};-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,${BUILD_PREFIX}/lib;-DCMAKE_MODULE_LINKER_FLAGS=;-DCMAKE_SHARED_LINKER_FLAGS="
+  NATIVE_FLAGS="${NATIVE_FLAGS};-DCMAKE_STATIC_LINKER_FLAGS=;-DLLVM_INCLUDE_BENCHMARKS=OFF"
+  NATIVE_FLAGS="${NATIVE_FLAGS};-DLLVM_ENABLE_ZSTD=OFF;-DLLVM_ENABLE_LIBXML2=OFF;-DLLVM_ENABLE_ZLIB=OFF;"
+  CMAKE_ARGS="${CMAKE_ARGS} -DCROSS_TOOLCHAIN_FLAGS_NATIVE=${NATIVE_FLAGS}"
 fi
+
+# TODO: Do we still need this?
+# if [[ "$CC_FOR_BUILD" != "" && "$CC_FOR_BUILD" != "$CC" ]]; then
+#   CMAKE_ARGS="${CMAKE_ARGS} -DCROSS_TOOLCHAIN_FLAGS_NATIVE=
+#   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_HOST_TRIPLE=$(echo $HOST | sed s/conda/unknown/g) -DLLVM_DEFAULT_TARGET_TRIPLE=$(echo $HOST | sed s/conda/unknown/g)"
+# fi
 
 # disable -fno-plt due to https://bugs.llvm.org/show_bug.cgi?id=51863 due to some GCC bug
 if [[ "$target_platform" == "linux-ppc64le" ]]; then
   CFLAGS="$(echo $CFLAGS | sed 's/-fno-plt //g')"
   CXXFLAGS="$(echo $CXXFLAGS | sed 's/-fno-plt //g')"
-  CMAKE_ARGS="${CMAKE_ARGS} -DFFI_INCLUDE_DIR=$PREFIX/include"
-  CMAKE_ARGS="${CMAKE_ARGS} -DFFI_LIBRARY_DIR=$PREFIX/lib"
 fi
 
 if [[ $target_platform == osx-* ]]; then
-  CMAKE_ARGS="${CMAKE_ARGS} -DFFI_INCLUDE_DIR=${CONDA_BUILD_SYSROOT}/usr/include/ffi"
-  CMAKE_ARGS="${CMAKE_ARGS} -DFFI_LIBRARY_DIR=${CONDA_BUILD_SYSROOT}/usr/lib"
+  # TODO: do we still need to link to ffi?
+  # CMAKE_ARGS="${CMAKE_ARGS} -DFFI_INCLUDE_DIR=${CONDA_BUILD_SYSROOT}/usr/include/ffi"
+  # CMAKE_ARGS="${CMAKE_ARGS} -DFFI_LIBRARY_DIR=${CONDA_BUILD_SYSROOT}/usr/lib"
   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_BUILD_LLVM_C_DYLIB=ON"
   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_LIBCXX=ON"
   CMAKE_ARGS="${CMAKE_ARGS} -DRUNTIMES_CMAKE_ARGS=-DCMAKE_INSTALL_RPATH=«loader_path/../lib"
@@ -42,8 +49,10 @@ fi
 cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_LIBRARY_PATH="${PREFIX}" \
+      -DLLVM_ENABLE_BACKTRACES=ON \
+      -DLLVM_ENABLE_DUMP=ON \
       -DLLVM_ENABLE_LIBEDIT=OFF \
-      -DLLVM_ENABLE_LIBXML2=OFF \
+      -DLLVM_ENABLE_LIBXML2=FORCE_ON \
       -DLLVM_ENABLE_RTTI=ON \
       -DLLVM_ENABLE_TERMINFO=OFF \
       -DLLVM_ENABLE_ZLIB=FORCE_ON \
@@ -56,16 +65,13 @@ cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
       -DLLVM_INCLUDE_UTILS=ON \
       -DLLVM_INSTALL_UTILS=ON \
       -DLLVM_UTILS_INSTALL_DIR=libexec/llvm \
-      -DLLVM_BUILD_LLVM_DYLIB=ON \
-      -DLLVM_LINK_LLVM_DYLIB=ON \
+      -DLLVM_BUILD_LLVM_DYLIB=yes \
+      -DLLVM_LINK_LLVM_DYLIB=yes \
       -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly \
-      -DLLVM_ENABLE_FFI=ON \
-      -DLLVM_ENABLE_Z3_SOLVER=OFF \
-      -DLLVM_OPTIMIZED_TABLEGEN=ON \
-      -DCMAKE_POLICY_DEFAULT_CMP0111=NEW \
       ${CMAKE_ARGS} \
       -GNinja \
       ../llvm
+
 
 ninja -j${CPU_COUNT}
 
@@ -75,29 +81,15 @@ else
     export TEST_CPU_FLAG=""
 fi
 
-if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
+if [[ ${CONDA_BUILD_CROSS_COMPILATION:-0} != "1" ]]; then
   # bin/opt -S -vector-library=SVML $TEST_CPU_FLAG -O3 $RECIPE_DIR/numba-3016.ll | bin/FileCheck $RECIPE_DIR/numba-3016.ll || exit $?
 
   if [[ "$target_platform" == linux* ]]; then
     ln -s $(which $CC) $BUILD_PREFIX/bin/gcc
-
-    # These tests tests permission-based behaviour and probably fail because of some
-    # filesystem-related reason. They are sporadic failures and don't seem serious so they're excluded.
-    # Note that indents would introduce spaces into the environment variable
-    export LIT_FILTER_OUT='tools/llvm-ar/error-opening-permission.test|'\
-'tools/llvm-dwarfdump/X86/output.s|'\
-'tools/llvm-ifs/fail-file-write.test|'\
-'tools/llvm-ranlib/error-opening-permission.test'
+    # check-llvm takes >1.5h to build & run on osx
+    ninja -j${CPU_COUNT} check-llvm
   fi
-
-  if [[ "$target_platform" == osx-* ]]; then
-    # This failure seems like something to do with the output format of ls -lu
-    # and looks harmless
-    export LIT_FILTER_OUT='tools/llvm-objcopy/ELF/strip-preserve-atime.test'
-  fi
-
-  ninja -j${CPU_COUNT} check-llvm
 
   cd ../llvm/test
-  ${PYTHON} ../../build/bin/llvm-lit -vv Transforms ExecutionEngine Analysis CodeGen/X86
+  python ../../build/bin/llvm-lit -vv Transforms ExecutionEngine Analysis CodeGen/X86
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,9 +8,10 @@ sed -i.bak "s/NOT APPLE AND NOT ARG_SONAME/NOT ARG_SONAME/g" llvm/cmake/modules/
 mkdir build
 cd build
 
-if [[ "$target_platform" == "linux-64" ]]; then
-  CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_USE_INTEL_JITEVENTS=ON"
-fi
+# TODO: TEMPORARILY DISABLING FOR TESTING PURPOSES
+# if [[ "$target_platform" == "linux-64" ]]; then
+#   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_USE_INTEL_JITEVENTS=ON"
+# fi
 
 if [[ "$CC_FOR_BUILD" != "" && "$CC_FOR_BUILD" != "$CC" ]]; then
   NATIVE_FLAGS="-DCMAKE_C_COMPILER=$CC_FOR_BUILD;-DCMAKE_CXX_COMPILER=$CXX_FOR_BUILD;-DCMAKE_C_FLAGS=-O2;-DCMAKE_CXX_FLAGS=-O2"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,9 +27,8 @@ if [[ "$target_platform" == "linux-ppc64le" ]]; then
 fi
 
 if [[ $target_platform == osx-* ]]; then
-  # TODO: do we still need to link to ffi?
-  # CMAKE_ARGS="${CMAKE_ARGS} -DFFI_INCLUDE_DIR=${CONDA_BUILD_SYSROOT}/usr/include/ffi"
-  # CMAKE_ARGS="${CMAKE_ARGS} -DFFI_LIBRARY_DIR=${CONDA_BUILD_SYSROOT}/usr/lib"
+  CMAKE_ARGS="${CMAKE_ARGS} -DFFI_INCLUDE_DIR=${CONDA_BUILD_SYSROOT}/usr/include/ffi"
+  CMAKE_ARGS="${CMAKE_ARGS} -DFFI_LIBRARY_DIR=${CONDA_BUILD_SYSROOT}/usr/lib"
   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_BUILD_LLVM_C_DYLIB=ON"
   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_LIBCXX=ON"
   CMAKE_ARGS="${CMAKE_ARGS} -DRUNTIMES_CMAKE_ARGS=-DCMAKE_INSTALL_RPATH=«loader_path/../lib"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,12 +20,6 @@ if [[ "$CC_FOR_BUILD" != "" && "$CC_FOR_BUILD" != "$CC" ]]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DCROSS_TOOLCHAIN_FLAGS_NATIVE=${NATIVE_FLAGS}"
 fi
 
-# TODO: Do we still need this?
-# if [[ "$CC_FOR_BUILD" != "" && "$CC_FOR_BUILD" != "$CC" ]]; then
-#   CMAKE_ARGS="${CMAKE_ARGS} -DCROSS_TOOLCHAIN_FLAGS_NATIVE=
-#   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_HOST_TRIPLE=$(echo $HOST | sed s/conda/unknown/g) -DLLVM_DEFAULT_TARGET_TRIPLE=$(echo $HOST | sed s/conda/unknown/g)"
-# fi
-
 # disable -fno-plt due to https://bugs.llvm.org/show_bug.cgi?id=51863 due to some GCC bug
 if [[ "$target_platform" == "linux-ppc64le" ]]; then
   CFLAGS="$(echo $CFLAGS | sed 's/-fno-plt //g')"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,6 +24,8 @@ fi
 if [[ "$target_platform" == "linux-ppc64le" ]]; then
   CFLAGS="$(echo $CFLAGS | sed 's/-fno-plt //g')"
   CXXFLAGS="$(echo $CXXFLAGS | sed 's/-fno-plt //g')"
+  CMAKE_ARGS="${CMAKE_ARGS} -DFFI_INCLUDE_DIR=$PREFIX/include"
+  CMAKE_ARGS="${CMAKE_ARGS} -DFFI_LIBRARY_DIR=$PREFIX/lib"
 fi
 
 if [[ $target_platform == osx-* ]]; then

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,18 +1,4 @@
-c_compiler:            # [win]
-- vs2019               # [win]
-cxx_compiler:          # [win]
-- vs2019               # [win]
-MACOSX_SDK_VERSION:    # [osx and x86_64]
-  - 10.12              # [osx and x86_64]
-CONDA_BUILD_SYSROOT:   # [osx and x86_64]
-  - /opt/MacOSX10.12.sdk  # [osx and x86_64]
-
-c_compiler:         # [osx]
-  - clang_bootstrap # [osx]
-cxx_compiler:       # [osx]
-  - clang_bootstrap # [osx]
-
-cxx_compiler_version:  # [linux and ppc64le]
-  # linking error with gcc 9
-  - 8                  # [linux and ppc64le]
-
+c_compiler:            # [osx]
+  - clang_bootstrap    # [osx]
+cxx_compiler:          # [osx]
+  - clang_bootstrap    # [osx]

--- a/recipe/install_llvm.sh
+++ b/recipe/install_llvm.sh
@@ -6,20 +6,52 @@ IFS='.' read -ra VER_ARR <<< "$PKG_VERSION"
 # temporary prefix to be able to install files more granularly
 mkdir temp_prefix
 
-# default SOVER for tagged releases is just the major version
-SOVER_EXT=${VER_ARR[0]}
-if [[ "${PKG_NAME}" == libllvm* ]]; then
+MAJOR_VER="${VER_ARR[0]}"
+MAJOR_EXT="${MAJOR_VER}"
+# default SOVER for tagged releases is major.minor version
+SOVER_EXT="${VER_ARR[0]}.${VER_ARR[1]}"
+# for rc's, both MAJOR_EXT & SOVER_EXT get suffixes
+if [[ "${PKG_VERSION}" == *rc* ]]; then
+    # rc's get "-rcX" suffix; in this case, PKG_VERSION has 4 parts,
+    # (e.g. 19.1.0.rc1), so take the last part after splitting on "."
+    MAJOR_EXT="${MAJOR_EXT}-${VER_ARR[3]}"
+    SOVER_EXT="${SOVER_EXT}-${VER_ARR[3]}"
+elif [[ "${PKG_VERSION}" == *dev* ]]; then
+    # otherwise with git suffix
+    MAJOR_EXT="${MAJOR_EXT}git"
+    SOVER_EXT="${SOVER_EXT}git"
+fi
+
+if [[ "${PKG_NAME}" == libllvm-c* ]]; then
+    cmake --install ./build --prefix=./temp_prefix
+    # only libLLVM-C
+    mv ./temp_prefix/lib/libLLVM-C${SOVER_EXT}${SHLIB_EXT} $PREFIX/lib
+elif [[ "${PKG_NAME}" == libllvm* ]]; then
     cmake --install ./build --prefix=./temp_prefix
     # all other libraries
-    mv ./temp_prefix/lib/libLLVM-${SOVER_EXT}${SHLIB_EXT} $PREFIX/lib
+    mv ./temp_prefix/lib/libLLVM-${MAJOR_EXT}${SHLIB_EXT} $PREFIX/lib
     mv ./temp_prefix/lib/lib*.so.${SOVER_EXT} $PREFIX/lib || true
     mv ./temp_prefix/lib/lib*.${SOVER_EXT}.dylib $PREFIX/lib || true
+elif [[ "${PKG_NAME}" == "llvm-tools-${MAJOR_VER}" ]]; then
+    cmake --install ./build --prefix=./temp_prefix
+    # install all binaries with a -${MAJOR_VER}
+    pushd ./temp_prefix
+      for f in bin/*; do
+        cp $f $PREFIX/bin/$(basename $f)-${MAJOR_VER}
+      done
+    popd
+    # except one binary that belongs to llvmdev
+    rm $PREFIX/bin/llvm-config-${MAJOR_VER}
 elif [[ "${PKG_NAME}" == "llvm-tools" ]]; then
     cmake --install ./build --prefix=./temp_prefix
-    # everything in /bin & /share
-    mv ./temp_prefix/bin/* $PREFIX/bin
+    # Install a symlink without the major version
+    pushd ./temp_prefix
+      for f in bin/*; do
+        ln -sf $PREFIX/bin/$(basename $f)-${MAJOR_VER} $PREFIX/bin/$(basename $f)
+      done
+    popd
+    # opt-viewer tool
     mv ./temp_prefix/share/* $PREFIX/share
-    # except one binary that belongs to llvmdev
     rm $PREFIX/bin/llvm-config
 else
     # llvmdev: install everything else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ source:
     # - patches/MSVC_DIA_SDK_path_fix.diff  # [win]
 
 build:
-  number: 3
+  number: 1
   # We only use this (and can test this) for pytorch, linux-64/GPU.
   skip: true  # [not (linux and x86_64)]
   merge_build_host: false
@@ -73,6 +73,7 @@ outputs:
         - libcxx {{ cxx_compiler_version }}  # [osx]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools", exact=True) }}
+        - libxml2 {{ libxml2 }}  # [win]
         - zlib
         - zstd
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,9 +46,8 @@ requirements:
     - git         # [(linux and x86_64)]
   host:
     - libcxx {{ cxx_compiler_version }}  # [osx]
-    #TODO - disabled this temporarily
-    # # needs aarch/ppc/arm (re)build of conda-forge/backtrace-feedstock
-    # - backtrace                          # [unix and x86]
+    # needs aarch/ppc/arm (re)build of backtrace-feedstock
+    - backtrace                          # [unix and x86]
     - libxml2
     - zlib
     - zstd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -273,8 +273,8 @@ outputs:
 
   - name: lit
     build:
-      script: python -m pip install llvm/utils/lit --no-deps -vv
-      # skip: true
+      script: python -m pip install llvm/utils/lit --no-deps --no-build-isolation -vv
+      skip: true  # [py<30]
       entry_points:
         # upstream LLVM is inconsistent; there's one way specified in lit's setup.py...
         - lit = lit.main:main
@@ -282,17 +282,19 @@ outputs:
         - llvm-lit = lit.main:main
     requirements:
       host:
-        - python >=3.9
+        - python
         - pip
         - setuptools
+        - wheel
       run:
-        - python >=3.9
+        - python
     test:
-      requires:
-        - python >=3.9
       imports:
         - lit
+      requires:
+        - pip
       commands:
+        - pip check
         - lit -h
         - llvm-lit -h
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,8 @@ source:
     - patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
     # - patches/0002-restore-macos-10.9-support.patch
     # These two patches remove expected test failures.
-    # - patches/0004-remove-unsupported-intrinsic-test.patch
-    # - patches/0005-remove-permission-based-unit-tests.patch
+    - patches/0004-remove-unsupported-intrinsic-test.patch
+    - patches/0005-remove-permission-based-unit-tests.patch
     # This patches cmake code which isn't hit in the current configuration, however it's kept in case we want to build
     # libllvm-c in the future
     # - patches/osx_ver.patch
@@ -313,6 +313,11 @@ about:
     optimizers, and run-time environments.
 
 extra:
+  skip-lints:
+    # there are false positives for these checks,
+    # for some of the individual outputs.
+    - missing_tests
+    - wrong_output_script_key
   recipe-maintainers:
     - JohanMabille
     - inducer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,9 @@ requirements:
     - git         # [(linux and x86_64)]
   host:
     - libcxx {{ cxx_compiler_version }}  # [osx]
+    - libffi {{ libffi }}                # [unix]
     - backtrace                          # [unix and x86]
-    - libxml2
+    - libxml2 {{ libxml2 }}
     - zlib
     - zstd
 
@@ -73,7 +74,7 @@ outputs:
         - libcxx {{ cxx_compiler_version }}  # [osx]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools", exact=True) }}
-        - libxml2 {{ libxml2 }}  # [win]
+        - libxml2 {{ libxml2 }}
         - zlib
         - zstd
       run:
@@ -123,12 +124,14 @@ outputs:
         - python >=3               # [not win]
       host:
         - libcxx {{ cxx_compiler_version }}  # [osx]
-        - libxml2   # [unix]
+        - libffi {{ libffi }}                # [unix]
+        - libxml2 {{ libxml2 }}
         - zlib
         - zstd
       run:
         # we need to do this manually because clang_bootstrap has no run-export
         - libcxx >={{ cxx_compiler_version }}  # [osx]
+        - {{ pin_compatible('libffi', max_pin='x.x') }}  # [unix]
     test:
       commands:
         # old style
@@ -149,7 +152,7 @@ outputs:
       build:
       host:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
-        - libxml2
+        - libxml2 {{ libxml2 }}
         - zlib
         - zstd
       run:                                                            # [not win]
@@ -218,10 +221,9 @@ outputs:
       host:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
-        # on unix, there's only symlinks
-        - libxml2   # [win]
-        - zlib      # [win]
-        - zstd      # [win]
+        - libxml2 {{ libxml2 }}
+        - zlib {{ zlib }}
+        - zstd {{ zstd }}
       run:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,6 @@ source:
     # - patches/expect-fastmath-entrypoints-in-add-TLI-mappings.ll.patch # adjusts test added in 10.0.0 for intel-D47188-svml-VF.patch effects
     # - patches/amd-roc-2.7.0.diff
     - patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
-
     # - patches/0002-restore-macos-10.9-support.patch
     # These two patches remove expected test failures.
     # - patches/0004-remove-unsupported-intrinsic-test.patch
@@ -48,7 +47,6 @@ requirements:
     - git         # [(linux and x86_64)]
   host:
     - libcxx {{ cxx_compiler_version }}  # [osx]
-    # needs aarch/ppc/arm (re)build of backtrace-feedstock
     - backtrace                          # [unix and x86]
     - libxml2
     - zlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,9 @@ requirements:
     - ninja
     - python >=3
     - libcxx {{ cxx_compiler_version }}  # [osx]
+    - patch       # [not win]
+    - m2-patch    # [win]
+    - git         # [(linux and x86_64)]
   host:
     - libcxx {{ cxx_compiler_version }}  # [osx]
     #TODO - disabled this temporarily

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,11 +47,11 @@ requirements:
     - git         # [(linux and x86_64)]
   host:
     - libcxx {{ cxx_compiler_version }}  # [osx]
-    - libffi {{ libffi }}                # [unix]
+    - libffi {{ libffi }}
     - backtrace                          # [unix and x86]
     - libxml2 {{ libxml2 }}
-    - zlib
-    - zstd
+    - zlib {{ zlib }}
+    - zstd {{ zstd }}
 
 outputs:
   # Contains everything
@@ -75,8 +75,8 @@ outputs:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools", exact=True) }}
         - libxml2 {{ libxml2 }}
-        - zlib
-        - zstd
+        - zlib {{ zlib }}
+        - zstd {{ zstd }}
       run:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools", exact=True) }}
@@ -124,14 +124,14 @@ outputs:
         - python >=3               # [not win]
       host:
         - libcxx {{ cxx_compiler_version }}  # [osx]
-        - libffi {{ libffi }}                # [unix]
+        - libffi {{ libffi }}
         - libxml2 {{ libxml2 }}
-        - zlib
-        - zstd
+        - zlib {{ zlib }}
+        - zstd {{ zstd }}
       run:
         # we need to do this manually because clang_bootstrap has no run-export
         - libcxx >={{ cxx_compiler_version }}  # [osx]
-        - {{ pin_compatible('libffi', max_pin='x.x') }}  # [unix]
+        - {{ pin_compatible('libffi', max_pin='x.x') }}
     test:
       commands:
         # old style
@@ -153,8 +153,8 @@ outputs:
       host:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
         - libxml2 {{ libxml2 }}
-        - zlib
-        - zstd
+        - zlib {{ zlib }}
+        - zstd {{ zstd }}
       run:                                                            # [not win]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
       run_constrained:
@@ -187,8 +187,8 @@ outputs:
       host:
         - libcxx {{ cxx_compiler_version }}  # [osx]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
-        - zlib
-        - zstd
+        - zlib {{ zlib }}
+        - zstd {{ zstd }}
       run:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
@@ -263,8 +263,8 @@ outputs:
       host:
         - libcxx {{ cxx_compiler_version }}  # [osx]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
-        - zlib
-        - zstd
+        - zlib {{ zlib }}
+        - zstd {{ zstd }}
       run_constrained:
         - llvmdev {{ version }}
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ source:
 
 build:
   number: 3
+  # We only use this (and can test this) for pytorch, linux-64/GPU.
+  skip: true  # [not (linux and x86_64)]
   merge_build_host: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,26 +1,37 @@
-{% set version = "17.0.6" %}
+{% set version = "19.1.7" %}
 {% set major_ver = version.split(".")[0] %}
+{% set tail_ver = version.split(".")[-1] %}
+{% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
+
+# as of LLVM 19, we expect an "-rcX" suffix for the release candidates
+{% set extra = "-" ~ tail_ver if tail_ver not in "0123456789" else "" %}
+{% set extra = "git" if tail_ver|trim("0123456789") == "dev" else extra %}
 
 package:
   name: llvm-package
   version: {{ version }}
 
 source:
-  url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
-  sha256: 58a8818c60e6627064f312dbf46c02d9949956558340938b71cf731ad8bc0813
+  url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
+  sha256: 59abea1c22e64933fad4de1671a61cdb934098793c7a31b333ff58dc41bff36c
   patches:
-    - patches/0002-restore-macos-10.9-support.patch
+    # - patches/intel-D47188-svml-VF.patch    # Fixes vectorizer and extends SVML support
+    # - patches/expect-fastmath-entrypoints-in-add-TLI-mappings.ll.patch # adjusts test added in 10.0.0 for intel-D47188-svml-VF.patch effects
+    # - patches/amd-roc-2.7.0.diff
+    - patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
+
+    # - patches/0002-restore-macos-10.9-support.patch
     # These two patches remove expected test failures.
-    - patches/0004-remove-unsupported-intrinsic-test.patch
-    - patches/0005-remove-permission-based-unit-tests.patch
+    # - patches/0004-remove-unsupported-intrinsic-test.patch
+    # - patches/0005-remove-permission-based-unit-tests.patch
     # This patches cmake code which isn't hit in the current configuration, however it's kept in case we want to build
     # libllvm-c in the future
-    - patches/osx_ver.patch
+    # - patches/osx_ver.patch
     # A different approach to this fix: https://github.com/conda-forge/llvmdev-feedstock/commit/1da42e54b055d26bc58da77bd1f88ad460ac90f4
-    - patches/MSVC_DIA_SDK_path_fix.diff  # [win]
+    # - patches/MSVC_DIA_SDK_path_fix.diff  # [win]
 
 build:
-  number: 1
+  number: 3
   merge_build_host: false
 
 requirements:
@@ -30,21 +41,19 @@ requirements:
     - ninja
     - python >=3
     - libcxx {{ cxx_compiler_version }}  # [osx]
-    - patch       # [not win]
-    - m2-patch    # [win]
-    - git         # [(linux and x86_64)]
   host:
     - libcxx {{ cxx_compiler_version }}  # [osx]
-    - libffi {{ libffi }}   # [unix]
-    # libxml2 supports a windows-only feature, see https://github.com/llvm/llvm-project/blob/llvmorg-17.0.6/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
-    - libxml2 {{ libxml2 }}  # [win]
-    - zlib {{ zlib }}
-    - zstd {{ zstd }}
+    #TODO - disabled this temporarily
+    # # needs aarch/ppc/arm (re)build of conda-forge/backtrace-feedstock
+    # - backtrace                          # [unix and x86]
+    - libxml2
+    - zlib
+    - zstd
 
 outputs:
   # Contains everything
   - name: llvmdev
-    script: install_llvm.sh  # [not win]
+    script: install_llvm.sh   # [unix]
     script: install_llvm.bat  # [win]
     build:
       skip: true  # [(win and vc<14)]
@@ -56,19 +65,29 @@ outputs:
         - cmake
         - ninja
         - python >=3
+        - m2-sed                             # [win]
+        - libcxx {{ cxx_compiler_version }}  # [osx]
       host:
-        - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
+        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools", exact=True) }}
-        - libxml2 {{ libxml2 }}  # [win]
-        - zlib {{ zlib }}
-        - zstd {{ zstd }}
+        - zlib
+        - zstd
       run:
-        - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
+        - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools", exact=True) }}
-        - libcxx >={{ cxx_compiler_version }}  # [osx]
+        - libcxx >={{ cxx_compiler_version }}                           # [osx]
+      run_constrained:
+        - llvm        {{ version }}
+        - llvm-tools  {{ version }}
+        - clang       {{ version }}
+        - clang-tools {{ version }}
     test:
+      requires:
+        - ripgrep  # [win]
+
       commands:
-        - $PREFIX/bin/llvm-config --libs                                 # [not win]
+        - $PREFIX/bin/llvm-config --libs                                # [not win]
         - test -f $PREFIX/include/llvm/Pass.h                           # [not win]
         - test -f $PREFIX/lib/libLLVMCore.a                             # [not win]
         - $PREFIX/libexec/llvm/not false                                # [not win]
@@ -78,61 +97,107 @@ outputs:
         - if not exist "%LIBRARY_BIN%"\\llvm-nm.exe exit 1              # [win]
         - llvm-nm.exe --help                                            # [win]
 
+        # ensure we've correctly inserted %VSINSTALLDIR% into the CMake metadata for LLVM;
+        # we're looking for: `INTERFACE_LINK_LIBRARIES "$ENV{VSINSTALLDIR}/DIA SDK/lib/amd64/diaguids.lib;[...]`instead
+        - rg -e "INTERFACE_LINK_LIBRARIES\s\"\$ENV\{VSINSTALLDIR\}[/\w\s]+/diaguids\.lib" %LIBRARY_LIB%\cmake\llvm\LLVMExports.cmake  # [win]
+
   # Contains the shared libraries. To make different LLVM libraries co-installable
   # soversion is appended to the package name.
   - name: libllvm{{ major_ver }}
     script: install_llvm.sh  # [not win]
     build:
+      activate_in_script: true
       skip: true  # [win and vc<14]
-      run_exports:   # [not win]
-        - {{ pin_subpackage("libllvm" + major_ver, max_pin="x.x") }}  # [not win]
+      run_exports:                                                    # [not win]
+        - {{ pin_subpackage("libllvm" ~ major_ver, max_pin="x.x") }}  # [not win]
       missing_dso_whitelist:  # [s390x]
         - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - ninja                  # [not win]
-        - cmake                  # [not win]
-        - python >=3             # [not win]
+        - ninja                    # [not win]
+        - cmake                    # [not win]
+        - python >=3               # [not win]
       host:
         - libcxx {{ cxx_compiler_version }}  # [osx]
-        - libffi {{ libffi }}  # [unix]
-        - libxml2 {{ libxml2 }}  # [win]
-        - zlib {{ zlib }}
-        - zstd {{ zstd }}
+        - libxml2   # [unix]
+        - zlib
+        - zstd
       run:
+        # we need to do this manually because clang_bootstrap has no run-export
         - libcxx >={{ cxx_compiler_version }}  # [osx]
-        - {{ pin_compatible('libffi', max_pin='x.x') }}  # [unix]
-        - zlib    # [osx]
     test:
       commands:
-        - test -f $PREFIX/lib/libLLVM-{{ major_ver }}${SHLIB_EXT}  # [not win]
+        # old style
+        - test -f $PREFIX/lib/libLLVM-{{ major_ver }}{{ extra }}.so     # [linux]
+        - test -f $PREFIX/lib/libLLVM-{{ major_ver }}{{ extra }}.dylib  # [osx]
+        # new style
+        - test -f $PREFIX/lib/libLLVM.so.{{ maj_min }}{{ extra }}       # [linux]
+        - test -f $PREFIX/lib/libLLVM.{{ maj_min }}{{ extra }}.dylib    # [osx]
 
   # This is a meta package so that people can use the latest libllvm and also
   # for run_exports
   - name: llvm
     build:
       skip: true  # [(win and vc<14)]
-      run_exports:   # [not win]
-        - {{ pin_subpackage("libllvm" + major_ver, max_pin="x.x") }}  # [not win]
+      run_exports:                                                    # [not win]
+        - {{ pin_subpackage("libllvm" ~ major_ver, max_pin="x.x") }}  # [not win]
     requirements:
       build:
       host:
-        - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}  # [not win]
-        - libxml2 {{ libxml2 }}  # [win]
-        - zlib {{ zlib }}
-        - zstd {{ zstd }}
-      run:   # [not win]
-        - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}  # [not win]
-      run_constrained:             # [not win]
-        - llvmdev   {{ version }}  # [not win]
+        - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
+        - libxml2
+        - zlib
+        - zstd
+      run:                                                            # [not win]
+        - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
+      run_constrained:
+        - llvmdev     {{ version }}
+        - llvm-tools  {{ version }}
+        - clang       {{ version }}
+        - clang-tools {{ version }}
     test:
       commands:
         - echo "Hello World!"
 
+  # Contains LLVM tools with a version suffix
+  - name: llvm-tools-{{ major_ver }}
+    script: install_llvm.sh   # [unix]
+    script: install_llvm.bat  # [win]
+    build:
+      activate_in_script: true
+      # On Windows there are no symlinks and copying will create a new package
+      # that is 300MB+
+      skip: true  # [win]
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+        - python >=3
+        - libcxx {{ cxx_compiler_version }}  # [osx]
+      host:
+        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
+        - zlib
+        - zstd
+      run:
+        - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
+        # we need to do this manually because clang_bootstrap has no run-export
+        - libcxx >={{ cxx_compiler_version }}  # [osx]
+    test:
+      commands:
+        - $PREFIX/bin/llc-{{ major_ver }} -version                               # [not win]
+        # The test for windows is split into two lines instead of having it in one line
+        # like its unix variant because of a YAML parsing issue.
+        - if not exist "%LIBRARY_BIN%"\\llc-{{ major_ver }}.exe exit 1           # [win]
+        - llc-{{ major_ver }} -version                                           # [win]
+        - test ! -f $PREFIX/bin/llvm-config-{{ major_ver }}                      # [not win]
+        - if exist "%LIBRARY_BIN%"\\llvm-config-{{ major_ver }}.exe exit 1       # [win]
+
   # Contains LLVM tools
   - name: llvm-tools
-    script: install_llvm.sh   # [not win]
+    script: install_llvm.sh   # [unix]
     script: install_llvm.bat  # [win]
     build:
       skip: true  # [(win and vc<14)]
@@ -144,27 +209,67 @@ outputs:
         - cmake
         - ninja
         - python >=3
-      host:
-        - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
-        - libxml2 {{ libxml2 }}  # [win]
-        - zlib {{ zlib }}
-        - zstd {{ zstd }}
         - libcxx {{ cxx_compiler_version }}  # [osx]
+      host:
+        - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
+        - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
+        # on unix, there's only symlinks
+        - libxml2   # [win]
+        - zlib      # [win]
+        - zstd      # [win]
       run:
-        - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
-        - libcxx >={{ cxx_compiler_version }}  # [osx]
+        - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
+        - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
       run_constrained:
-        - llvmdev   {{ version }}
+        - llvm        {{ version }}
+        - llvmdev     {{ version }}
+        - clang       {{ version }}
+        - clang-tools {{ version }}
     test:
       commands:
         - $PREFIX/bin/llc -version                               # [not win]
+        # The test for windows is split into two lines instead of having it in one line
+        # like its unix variant because of a YAML parsing issue.
         - if not exist "%LIBRARY_BIN%"\\llc.exe exit 1           # [win]
         - llc -version                                           # [win]
+        - test ! -f $PREFIX/bin/llvm-config                      # [not win]
+        - if exist "%LIBRARY_BIN%"\\llvm-config.exe exit 1       # [win]
+
+  # Contains LLVM-C shared library
+  - name: libllvm-c{{ major_ver }}
+    script: install_llvm.sh   # [unix]
+    script: install_llvm.bat  # [win]
+    build:
+      run_exports:
+        - {{ pin_subpackage("libllvm-c" ~ major_ver, max_pin="x.x") }}
+      activate_in_script: true
+      # not supported on linux, see
+      # https://github.com/llvm/llvm-project/blob/llvmorg-16.0.6/llvm/tools/llvm-shlib/CMakeLists.txt#L82-L85
+      # osx currently fails as well, see https://github.com/llvm/llvm-project/issues/64657
+      skip: true  # [not win]
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+        - libcxx {{ cxx_compiler_version }}  # [osx]
+      host:
+        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
+        - zlib
+        - zstd
+      run_constrained:
+        - llvmdev {{ version }}
+    test:
+      commands:
+        - test -f $PREFIX/lib/libLLVM-C.{{ major_ver }}.dylib   # [osx]
+        - if not exist %LIBRARY_BIN%\LLVM-C.dll exit 1          # [win]
+        - if not exist %LIBRARY_LIB%\LLVM-C.lib exit 1          # [win]
 
   - name: lit
     build:
-      script: python -m pip install llvm/utils/lit --no-deps --no-build-isolation -vv
-      skip: true  # [py<30]
+      script: python -m pip install llvm/utils/lit --no-deps -vv
+      # skip: true
       entry_points:
         # upstream LLVM is inconsistent; there's one way specified in lit's setup.py...
         - lit = lit.main:main
@@ -172,19 +277,17 @@ outputs:
         - llvm-lit = lit.main:main
     requirements:
       host:
-        - python
+        - python >=3.9
         - pip
         - setuptools
-        - wheel
       run:
-        - python
+        - python >=3.9
     test:
+      requires:
+        - python >=3.9
       imports:
         - lit
-      requires:
-        - pip
       commands:
-        - pip check
         - lit -h
         - llvm-lit -h
 
@@ -201,13 +304,8 @@ about:
     optimizers, and run-time environments.
 
 extra:
-  skip-lints:
-    # there are false positives for these checks,
-    # for some of the individual outputs.
-    - output_missing_script
-    - missing_tests
-    - wrong_output_script_key
   recipe-maintainers:
+    - JohanMabille
     - inducer
     - jakirkham
     - mingwandroid
@@ -217,3 +315,4 @@ extra:
     - xhochy
     - h-vetinari
     - danpetry
+  feedstock-name: llvmdev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -172,6 +172,8 @@ outputs:
       # On Windows there are no symlinks and copying will create a new package
       # that is 300MB+
       skip: true  # [win]
+      missing_dso_whitelist:  # [s390x]
+        - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
         - {{ compiler('cxx') }}

--- a/recipe/patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
+++ b/recipe/patches/0001-pass-through-QEMU_LD_PREFIX-SDKROOT.patch
@@ -1,0 +1,22 @@
+From f2ee4893b93c254d97fd51fe6f6ee605934cf6a9 Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Tue, 4 Aug 2020 21:06:30 -0500
+Subject: [PATCH 1/2] pass through QEMU_LD_PREFIX & SDKROOT
+
+---
+ llvm/utils/lit/lit/TestingConfig.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/llvm/utils/lit/lit/TestingConfig.py b/llvm/utils/lit/lit/TestingConfig.py
+index 76fd66502009..3009e921b621 100644
+--- a/llvm/utils/lit/lit/TestingConfig.py
++++ b/llvm/utils/lit/lit/TestingConfig.py
+@@ -25,6 +25,8 @@ class TestingConfig(object):
+             "LD_LIBRARY_PATH",
+             "SYSTEMROOT",
+             "TERM",
++            "QEMU_LD_PREFIX",
++            "SDKROOT",
+             "CLANG",
+             "LLDB",
+             "LD_PRELOAD",


### PR DESCRIPTION
llvm 19.1.7 (linux-64 only)

Destination channel: defaults

Links
- [PKG-7227](https://anaconda.atlassian.net/browse/PKG-7227)

Explanation of changes:
- Updated for llvm 19

[PKG-7227]: https://anaconda.atlassian.net/browse/PKG-7227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ