### PR TITLE
llvmdev 20.1.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -8,10 +8,8 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-staging_channel_upload_target: llvm-20.1.8-stage1-build-0
+staging_channel_upload_target: llvm-20.1.8-stage2-build-0
 
 channels:
   - https://staging.continuum.io/prefect/llvm-20.1.8-stage1-build-0
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-1
-
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,6 +4,10 @@
 extra_labels_for_os:
   osx-arm64: [ventura]
 
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+
 staging_channel_upload_target: llvm-20.1.8-stage0-build-1
 
 channels:

--- a/abs.yaml
+++ b/abs.yaml
@@ -8,10 +8,10 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-staging_channel_upload_target: llvm-20.1.8-stage0-build-1
+staging_channel_upload_target: llvm-20.1.8-stage1-build-0
 
 channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-0
-  - https://staging.continuum.io/prefect/llvm-19.1.7-stage1-build-2
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage1-build-0
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-1
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -8,9 +8,10 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-staging_channel_upload_target: llvm-19.1.7-stage2-build-0
+staging_channel_upload_target: llvm-20.1.8-stage0-build-0
 
 channels:
   - https://staging.continuum.io/prefect/llvm-19.1.7-stage1-build-2
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage0-build-0
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,10 +4,6 @@
 extra_labels_for_os:
   osx-arm64: [ventura]
 
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-
 staging_channel_upload_target: llvm-20.1.8-stage0-build-0
 
 channels:

--- a/abs.yaml
+++ b/abs.yaml
@@ -7,9 +7,6 @@ extra_labels_for_os:
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
+  - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"
 
-staging_channel_upload_target: llvm-20.1.8-stage2-build-0
-
-channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage1-build-0
 aggregate_check: false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,9 +6,9 @@ cxx_compiler:
   - vs2022                     # [win]
 
 c_compiler_version:
-  - 19.1.7            # [osx]
+  - 20.1.8            # [osx]
 cxx_compiler_version:
-  - 19.1.7            # [osx]
+  - 20.1.8            # [osx]
 
 c_stdlib_version:   # [win]
   - 2022.14         # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "19.1.7" %}
+{% set version = "20.1.8" %}
 {% set major_ver = version.split(".")[0] %}
 {% set tail_ver = version.split(".")[-1] %}
 {% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
@@ -13,13 +13,13 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: 59abea1c22e64933fad4de1671a61cdb934098793c7a31b333ff58dc41bff36c
+  sha256: a6cbad9b2243b17e87795817cfff2107d113543a12486586f8a055a2bb044963
   patches:
     - patches/0004-remove-unsupported-intrinsic-test.patch
     - patches/0005-remove-permission-based-unit-tests.patch
 
 build:
-  number: 4
+  number: 0
   merge_build_host: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,11 +70,11 @@ outputs:
         - {{ pin_subpackage("llvm-tools", exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
         - libcxx >={{ cxx_compiler_version }}                           # [osx]
-      run_constrained:
-        - llvm        {{ version }}
-        - llvm-tools  {{ version }}
-        - clang       {{ version }}
-        - clang-tools {{ version }}
+      # run_constrained:
+      #   - llvm        {{ version }}
+      #   - llvm-tools  {{ version }}
+      #   - clang       {{ version }}
+      #   - clang-tools {{ version }}
     test:
       requires:
         - ripgrep  # [win]
@@ -142,11 +142,11 @@ outputs:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
       run:                                                            # [not win]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
-      run_constrained:
-        - llvmdev     {{ version }}
-        - llvm-tools  {{ version }}
-        - clang       {{ version }}
-        - clang-tools {{ version }}
+      # run_constrained:
+      #   - llvmdev     {{ version }}
+      #   - llvm-tools  {{ version }}
+      #   - clang       {{ version }}
+      #   - clang-tools {{ version }}
     test:
       commands:
         - echo "Hello World!"
@@ -211,11 +211,11 @@ outputs:
       run:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
-      run_constrained:
-        - llvm        {{ version }}
-        - llvmdev     {{ version }}
-        - clang       {{ version }}
-        - clang-tools {{ version }}
+      # run_constrained:
+      #   - llvm        {{ version }}
+      #   - llvmdev     {{ version }}
+      #   - clang       {{ version }}
+      #   - clang-tools {{ version }}
     test:
       commands:
         - $PREFIX/bin/llc -version                               # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ source:
   patches:
     - patches/0004-remove-unsupported-intrinsic-test.patch
     - patches/0005-remove-permission-based-unit-tests.patch
+    # These tests pass on a dev instance with more resources, but fail on CI.
+    - patches/0006-win-disable-orcjittests.patch  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,11 +72,11 @@ outputs:
         - {{ pin_subpackage("llvm-tools", exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
         - libcxx >={{ cxx_compiler_version }}                           # [osx]
-      # run_constrained:
-      #   - llvm        {{ version }}
-      #   - llvm-tools  {{ version }}
-      #   - clang       {{ version }}
-      #   - clang-tools {{ version }}
+      run_constrained:
+        - llvm        {{ version }}
+        - llvm-tools  {{ version }}
+        - clang       {{ version }}
+        - clang-tools {{ version }}
     test:
       requires:
         - ripgrep  # [win]
@@ -144,11 +144,11 @@ outputs:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
       run:                                                            # [not win]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
-      # run_constrained:
-      #   - llvmdev     {{ version }}
-      #   - llvm-tools  {{ version }}
-      #   - clang       {{ version }}
-      #   - clang-tools {{ version }}
+      run_constrained:
+        - llvmdev     {{ version }}
+        - llvm-tools  {{ version }}
+        - clang       {{ version }}
+        - clang-tools {{ version }}
     test:
       commands:
         - echo "Hello World!"
@@ -213,11 +213,11 @@ outputs:
       run:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
-      # run_constrained:
-      #   - llvm        {{ version }}
-      #   - llvmdev     {{ version }}
-      #   - clang       {{ version }}
-      #   - clang-tools {{ version }}
+      run_constrained:
+        - llvm        {{ version }}
+        - llvmdev     {{ version }}
+        - clang       {{ version }}
+        - clang-tools {{ version }}
     test:
       commands:
         - $PREFIX/bin/llc -version                               # [not win]

--- a/recipe/patches/0006-win-disable-orcjittests.patch
+++ b/recipe/patches/0006-win-disable-orcjittests.patch
@@ -1,134 +1,27 @@
-From 1430203401dbf4e7a4054949a65d9c90d47def94 Mon Sep 17 00:00:00 2001
+From 1430203401dbf4e7a4054949a65d9c90d47def95 Mon Sep 17 00:00:00 2001
 From: Eric Lundby <Eric.Lundby@gmail.com>
 Date: Fri, 8 Aug 2025 08:15:24 -0600
-Subject: [PATCH 1/1] win-disable-orcjittests
+Subject: [PATCH 1/1] cmake-disable-orcjittests-on-windows
 
 ---
- .../gn/secondary/llvm/unittests/BUILD.gn      |   2 +-
- .../unittests/ExecutionEngine/Orc/BUILD.gn    | 101 +++++++++---------
- 2 files changed, 52 insertions(+), 51 deletions(-)
+ llvm/unittests/ExecutionEngine/CMakeLists.txt     |  6 +++++-
+ llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt | 54 ++++++++++++++--------
+ 1 file changed, 5 insertions(+), 1 deletions(-)
 
-diff --git a/llvm/utils/gn/secondary/llvm/unittests/BUILD.gn b/llvm/utils/gn/secondary/llvm/unittests/BUILD.gn
-index 0d01bfa98017..4882de3fb7e4 100644
---- a/llvm/utils/gn/secondary/llvm/unittests/BUILD.gn
-+++ b/llvm/utils/gn/secondary/llvm/unittests/BUILD.gn
-@@ -25,7 +25,7 @@ group("unittests") {
-     "ExecutionEngine:ExecutionEngineTests",
-     "ExecutionEngine/JITLink:JITLinkTests",
-     "ExecutionEngine/MCJIT:MCJITTests",
--    "ExecutionEngine/Orc:OrcJITTests",
-+    # "ExecutionEngine/Orc:OrcJITTests",  # Disabled
-     "FileCheck:FileCheckTests",
-     "Frontend:LLVMFrontendTests",
-     "FuzzMutate:FuzzMutateTests",
-diff --git a/llvm/utils/gn/secondary/llvm/unittests/ExecutionEngine/Orc/BUILD.gn b/llvm/utils/gn/secondary/llvm/unittests/ExecutionEngine/Orc/BUILD.gn
-index 376f68977ed6..4781e4a2cc54 100644
---- a/llvm/utils/gn/secondary/llvm/unittests/ExecutionEngine/Orc/BUILD.gn
-+++ b/llvm/utils/gn/secondary/llvm/unittests/ExecutionEngine/Orc/BUILD.gn
-@@ -1,52 +1,53 @@
- import("//third-party/unittest/unittest.gni")
+diff --git a/llvm/unittests/ExecutionEngine/CMakeLists.txt b/llvm/unittests/ExecutionEngine/CMakeLists.txt
+index 1bf210556b66..0a6d80207544 100644
+--- a/llvm/unittests/ExecutionEngine/CMakeLists.txt
++++ b/llvm/unittests/ExecutionEngine/CMakeLists.txt
+@@ -13,7 +13,11 @@ add_llvm_unittest(ExecutionEngineTests
+   )
  
--unittest("OrcJITTests") {
--  deps = [
--    "//llvm/lib/ExecutionEngine",
--    "//llvm/lib/ExecutionEngine/Orc",
--    "//llvm/lib/ExecutionEngine/Orc/Debugging",
--    "//llvm/lib/ExecutionEngine/Orc/Shared",
--    "//llvm/lib/ExecutionEngine/RuntimeDyld",
--    "//llvm/lib/IR",
--    "//llvm/lib/Object",
--    "//llvm/lib/Support",
--    "//llvm/lib/Target:NativeTarget",
--    "//llvm/lib/TargetParser",
--    "//llvm/lib/Testing/Support",
--  ]
--  sources = [
--    "CoreAPIsTest.cpp",
--    "EPCGenericJITLinkMemoryManagerTest.cpp",
--    "EPCGenericMemoryAccessTest.cpp",
--    "ExecutionSessionWrapperFunctionCallsTest.cpp",
--    "ExecutorAddressTest.cpp",
--    "IndirectionUtilsTest.cpp",
--    "JITLinkRedirectionManagerTest.cpp",
--    "JITTargetMachineBuilderTest.cpp",
--    "LazyCallThroughAndReexportsTest.cpp",
--    "LookupAndRecordAddrsTest.cpp",
--    "MachOPlatformTest.cpp",
--    "MapperJITLinkMemoryManagerTest.cpp",
--    "MemoryFlagsTest.cpp",
--    "MemoryMapperTest.cpp",
--    "ObjectFormatsTest.cpp",
--    "ObjectLinkingLayerTest.cpp",
--    "OrcCAPITest.cpp",
--    "OrcTestCommon.cpp",
--    "RTDyldObjectLinkingLayerTest.cpp",
--    "ReOptimizeLayerTest.cpp",
--    "ResourceTrackerTest.cpp",
--    "SharedMemoryMapperTest.cpp",
--    "SimpleExecutorMemoryManagerTest.cpp",
--    "SimplePackedSerializationTest.cpp",
--    "SymbolStringPoolTest.cpp",
--    "TaskDispatchTest.cpp",
--    "ThreadSafeModuleTest.cpp",
--    "WrapperFunctionUtilsTest.cpp",
--  ]
--
--  if (host_os != "mac" && host_os != "win") {
--    # Corresponds to export_executable_symbols() in cmake.
--    ldflags = [ "-rdynamic" ]
--  }
--}
-+# Disabled OrcJITTests
-+# unittest("OrcJITTests") {
-+#   deps = [
-+#     "//llvm/lib/ExecutionEngine",
-+#     "//llvm/lib/ExecutionEngine/Orc",
-+#     "//llvm/lib/ExecutionEngine/Orc/Debugging",
-+#     "//llvm/lib/ExecutionEngine/Orc/Shared",
-+#     "//llvm/lib/ExecutionEngine/RuntimeDyld",
-+#     "//llvm/lib/IR",
-+#     "//llvm/lib/Object",
-+#     "//llvm/lib/Support",
-+#     "//llvm/lib/Target:NativeTarget",
-+#     "//llvm/lib/TargetParser",
-+#     "//llvm/lib/Testing/Support",
-+#   ]
-+#   sources = [
-+#     "CoreAPIsTest.cpp",
-+#     "EPCGenericJITLinkMemoryManagerTest.cpp",
-+#     "EPCGenericMemoryAccessTest.cpp",
-+#     "ExecutionSessionWrapperFunctionCallsTest.cpp",
-+#     "ExecutorAddressTest.cpp",
-+#     "IndirectionUtilsTest.cpp",
-+#     "JITLinkRedirectionManagerTest.cpp",
-+#     "JITTargetMachineBuilderTest.cpp",
-+#     "LazyCallThroughAndReexportsTest.cpp",
-+#     "LookupAndRecordAddrsTest.cpp",
-+#     "MachOPlatformTest.cpp",
-+#     "MapperJITLinkMemoryManagerTest.cpp",
-+#     "MemoryFlagsTest.cpp",
-+#     "MemoryMapperTest.cpp",
-+#     "ObjectFormatsTest.cpp",
-+#     "ObjectLinkingLayerTest.cpp",
-+#     "OrcCAPITest.cpp",
-+#     "OrcTestCommon.cpp",
-+#     "RTDyldObjectLinkingLayerTest.cpp",
-+#     "ReOptimizeLayerTest.cpp",
-+#     "ResourceTrackerTest.cpp",
-+#     "SharedMemoryMapperTest.cpp",
-+#     "SimpleExecutorMemoryManagerTest.cpp",
-+#     "SimplePackedSerializationTest.cpp",
-+#     "SymbolStringPoolTest.cpp",
-+#     "TaskDispatchTest.cpp",
-+#     "ThreadSafeModuleTest.cpp",
-+#     "WrapperFunctionUtilsTest.cpp",
-+#   ]
-+# 
-+#   if (host_os != "mac" && host_os != "win") {
-+#     # Corresponds to export_executable_symbols() in cmake.
-+#     ldflags = [ "-rdynamic" ]
-+#   }
-+# }
--- 
-2.45.2
-
+ add_subdirectory(JITLink)
+-add_subdirectory(Orc)
++
++# Disable OrcJITTests on Windows due to test failures
++if(NOT WIN32)
++  add_subdirectory(Orc)
++endif()
+ 
+ # Include MCJIT tests only if native arch is a built JIT target.
+ list(FIND LLVM_TARGETS_TO_BUILD "${LLVM_NATIVE_ARCH}" build_idx)

--- a/recipe/patches/0006-win-disable-orcjittests.patch
+++ b/recipe/patches/0006-win-disable-orcjittests.patch
@@ -1,0 +1,134 @@
+From 1430203401dbf4e7a4054949a65d9c90d47def94 Mon Sep 17 00:00:00 2001
+From: Eric Lundby <Eric.Lundby@gmail.com>
+Date: Fri, 8 Aug 2025 08:15:24 -0600
+Subject: [PATCH 1/1] win-disable-orcjittests
+
+---
+ .../gn/secondary/llvm/unittests/BUILD.gn      |   2 +-
+ .../unittests/ExecutionEngine/Orc/BUILD.gn    | 101 +++++++++---------
+ 2 files changed, 52 insertions(+), 51 deletions(-)
+
+diff --git a/llvm/utils/gn/secondary/llvm/unittests/BUILD.gn b/llvm/utils/gn/secondary/llvm/unittests/BUILD.gn
+index 0d01bfa98017..4882de3fb7e4 100644
+--- a/llvm/utils/gn/secondary/llvm/unittests/BUILD.gn
++++ b/llvm/utils/gn/secondary/llvm/unittests/BUILD.gn
+@@ -25,7 +25,7 @@ group("unittests") {
+     "ExecutionEngine:ExecutionEngineTests",
+     "ExecutionEngine/JITLink:JITLinkTests",
+     "ExecutionEngine/MCJIT:MCJITTests",
+-    "ExecutionEngine/Orc:OrcJITTests",
++    # "ExecutionEngine/Orc:OrcJITTests",  # Disabled
+     "FileCheck:FileCheckTests",
+     "Frontend:LLVMFrontendTests",
+     "FuzzMutate:FuzzMutateTests",
+diff --git a/llvm/utils/gn/secondary/llvm/unittests/ExecutionEngine/Orc/BUILD.gn b/llvm/utils/gn/secondary/llvm/unittests/ExecutionEngine/Orc/BUILD.gn
+index 376f68977ed6..4781e4a2cc54 100644
+--- a/llvm/utils/gn/secondary/llvm/unittests/ExecutionEngine/Orc/BUILD.gn
++++ b/llvm/utils/gn/secondary/llvm/unittests/ExecutionEngine/Orc/BUILD.gn
+@@ -1,52 +1,53 @@
+ import("//third-party/unittest/unittest.gni")
+ 
+-unittest("OrcJITTests") {
+-  deps = [
+-    "//llvm/lib/ExecutionEngine",
+-    "//llvm/lib/ExecutionEngine/Orc",
+-    "//llvm/lib/ExecutionEngine/Orc/Debugging",
+-    "//llvm/lib/ExecutionEngine/Orc/Shared",
+-    "//llvm/lib/ExecutionEngine/RuntimeDyld",
+-    "//llvm/lib/IR",
+-    "//llvm/lib/Object",
+-    "//llvm/lib/Support",
+-    "//llvm/lib/Target:NativeTarget",
+-    "//llvm/lib/TargetParser",
+-    "//llvm/lib/Testing/Support",
+-  ]
+-  sources = [
+-    "CoreAPIsTest.cpp",
+-    "EPCGenericJITLinkMemoryManagerTest.cpp",
+-    "EPCGenericMemoryAccessTest.cpp",
+-    "ExecutionSessionWrapperFunctionCallsTest.cpp",
+-    "ExecutorAddressTest.cpp",
+-    "IndirectionUtilsTest.cpp",
+-    "JITLinkRedirectionManagerTest.cpp",
+-    "JITTargetMachineBuilderTest.cpp",
+-    "LazyCallThroughAndReexportsTest.cpp",
+-    "LookupAndRecordAddrsTest.cpp",
+-    "MachOPlatformTest.cpp",
+-    "MapperJITLinkMemoryManagerTest.cpp",
+-    "MemoryFlagsTest.cpp",
+-    "MemoryMapperTest.cpp",
+-    "ObjectFormatsTest.cpp",
+-    "ObjectLinkingLayerTest.cpp",
+-    "OrcCAPITest.cpp",
+-    "OrcTestCommon.cpp",
+-    "RTDyldObjectLinkingLayerTest.cpp",
+-    "ReOptimizeLayerTest.cpp",
+-    "ResourceTrackerTest.cpp",
+-    "SharedMemoryMapperTest.cpp",
+-    "SimpleExecutorMemoryManagerTest.cpp",
+-    "SimplePackedSerializationTest.cpp",
+-    "SymbolStringPoolTest.cpp",
+-    "TaskDispatchTest.cpp",
+-    "ThreadSafeModuleTest.cpp",
+-    "WrapperFunctionUtilsTest.cpp",
+-  ]
+-
+-  if (host_os != "mac" && host_os != "win") {
+-    # Corresponds to export_executable_symbols() in cmake.
+-    ldflags = [ "-rdynamic" ]
+-  }
+-}
++# Disabled OrcJITTests
++# unittest("OrcJITTests") {
++#   deps = [
++#     "//llvm/lib/ExecutionEngine",
++#     "//llvm/lib/ExecutionEngine/Orc",
++#     "//llvm/lib/ExecutionEngine/Orc/Debugging",
++#     "//llvm/lib/ExecutionEngine/Orc/Shared",
++#     "//llvm/lib/ExecutionEngine/RuntimeDyld",
++#     "//llvm/lib/IR",
++#     "//llvm/lib/Object",
++#     "//llvm/lib/Support",
++#     "//llvm/lib/Target:NativeTarget",
++#     "//llvm/lib/TargetParser",
++#     "//llvm/lib/Testing/Support",
++#   ]
++#   sources = [
++#     "CoreAPIsTest.cpp",
++#     "EPCGenericJITLinkMemoryManagerTest.cpp",
++#     "EPCGenericMemoryAccessTest.cpp",
++#     "ExecutionSessionWrapperFunctionCallsTest.cpp",
++#     "ExecutorAddressTest.cpp",
++#     "IndirectionUtilsTest.cpp",
++#     "JITLinkRedirectionManagerTest.cpp",
++#     "JITTargetMachineBuilderTest.cpp",
++#     "LazyCallThroughAndReexportsTest.cpp",
++#     "LookupAndRecordAddrsTest.cpp",
++#     "MachOPlatformTest.cpp",
++#     "MapperJITLinkMemoryManagerTest.cpp",
++#     "MemoryFlagsTest.cpp",
++#     "MemoryMapperTest.cpp",
++#     "ObjectFormatsTest.cpp",
++#     "ObjectLinkingLayerTest.cpp",
++#     "OrcCAPITest.cpp",
++#     "OrcTestCommon.cpp",
++#     "RTDyldObjectLinkingLayerTest.cpp",
++#     "ReOptimizeLayerTest.cpp",
++#     "ResourceTrackerTest.cpp",
++#     "SharedMemoryMapperTest.cpp",
++#     "SimpleExecutorMemoryManagerTest.cpp",
++#     "SimplePackedSerializationTest.cpp",
++#     "SymbolStringPoolTest.cpp",
++#     "TaskDispatchTest.cpp",
++#     "ThreadSafeModuleTest.cpp",
++#     "WrapperFunctionUtilsTest.cpp",
++#   ]
++# 
++#   if (host_os != "mac" && host_os != "win") {
++#     # Corresponds to export_executable_symbols() in cmake.
++#     ldflags = [ "-rdynamic" ]
++#   }
++# }
+-- 
+2.45.2
+


### PR DESCRIPTION
llvmdev v20.1.8

## Links
- [PKG-8673](https://anaconda.atlassian.net/browse/PKG-8673)
- [Artifacts](https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0)

## Changes
- Bump version and SHA, reset build number
- Build with llvm 20
- Skips a problematic test on windows 

## Related PRs
- ✅ https://github.com/AnacondaRecipes/cctools-and-ld64-feedstock/pull/17
- ✅  https://github.com/AnacondaRecipes/clang-compiler-activation-feedstock/pull/23
- https://github.com/AnacondaRecipes/libcxx-feedstock/pull/15
- https://github.com/AnacondaRecipes/llvmdev-feedstock/pull/29
- https://github.com/AnacondaRecipes/clangdev-feedstock/pull/16
- https://github.com/AnacondaRecipes/compiler-rt-feedstock/pull/9
-  ✅ https://github.com/AnacondaRecipes/mlir-feedstock/pull/8
-  ✅ https://github.com/AnacondaRecipes/lld-feedstock/pull/12
- https://github.com/AnacondaRecipes/openmp-feedstock/pull/6
- https://github.com/AnacondaRecipes/clang-win-activation-feedstock/pull/6
- https://github.com/AnacondaRecipes/flang-feedstock/pull/2
- https://github.com/AnacondaRecipes/flang-activation-feedstock/pull/1


[PKG-8673]: https://anaconda.atlassian.net/browse/PKG-8673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ