### PR TITLE
Update llvmdev to 22.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -11,9 +11,8 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
-channels:
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+# Stage 0: Upload to LLVM 22 staging channel
+staging_channel_upload_target: llvm-22.1.2-stage0-build-0
 
 aggregate_check: false
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,7 +5,7 @@ cxx_compiler:
   - clang_bootstrap            # [osx]
   - vs2022                     # [win]
 
-# Stage 2: Self-hosted build with clang 21 compiler
+# Stage 0: Bootstrap build with clang 21 compiler (update to 22.1.2 in Stage 2)
 c_compiler_version:
   - 21.1.8            # [osx]
 cxx_compiler_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.1.8" %}
+{% set version = "22.1.2" %}
 {% set major_ver = version.split(".")[0] %}
 {% set tail_ver = version.split(".")[-1] %}
 {% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
@@ -13,7 +13,7 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
+  sha256: a252efd7a4a268d2cc5145b17adcaa82757fdee1d06d748b4c24137807710ecb
   patches:
     - patches/0004-remove-unsupported-intrinsic-test.patch
     - patches/0005-remove-permission-based-unit-tests.patch
@@ -76,11 +76,12 @@ outputs:
         - {{ pin_subpackage("llvm-tools", exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
         - libcxx >={{ cxx_compiler_version }}                           # [osx]
-      run_constrained:
-        - llvm        {{ version }}
-        - llvm-tools  {{ version }}
-        - clang       {{ version }}
-        - clang-tools {{ version }}
+      # Stage 0: run_constrained disabled (re-enable in Stage 2)
+      # run_constrained:
+      #   - llvm        {{ version }}
+      #   - llvm-tools  {{ version }}
+      #   - clang       {{ version }}
+      #   - clang-tools {{ version }}
     test:
       requires:
         - ripgrep  # [win]
@@ -148,11 +149,12 @@ outputs:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
       run:                                                            # [not win]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
-      run_constrained:
-        - llvmdev     {{ version }}
-        - llvm-tools  {{ version }}
-        - clang       {{ version }}
-        - clang-tools {{ version }}
+      # Stage 0: run_constrained disabled (re-enable in Stage 2)
+      # run_constrained:
+      #   - llvmdev     {{ version }}
+      #   - llvm-tools  {{ version }}
+      #   - clang       {{ version }}
+      #   - clang-tools {{ version }}
     test:
       commands:
         - echo "Hello World!"
@@ -217,11 +219,12 @@ outputs:
       run:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
-      run_constrained:
-        - llvm        {{ version }}
-        - llvmdev     {{ version }}
-        - clang       {{ version }}
-        - clang-tools {{ version }}
+      # Stage 0: run_constrained disabled (re-enable in Stage 2)
+      # run_constrained:
+      #   - llvm        {{ version }}
+      #   - llvmdev     {{ version }}
+      #   - clang       {{ version }}
+      #   - clang-tools {{ version }}
     test:
       commands:
         - $PREFIX/bin/llc -version                               # [not win]
@@ -256,8 +259,9 @@ outputs:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - zlib {{ zlib }}
         - zstd {{ zstd }}
-      run_constrained:
-        - llvmdev {{ version }}
+      # Stage 0: run_constrained disabled (re-enable in Stage 2)
+      # run_constrained:
+      #   - llvmdev {{ version }}
     test:
       commands:
         - test -f $PREFIX/lib/libLLVM-C.{{ major_ver }}.dylib   # [osx]


### PR DESCRIPTION
## Description

Update llvmdev from 21.1.8 to 22.1.2 (LLVM 22 update).

**Stage 0:** Bootstrap build using LLVM 21 compiler.

- Updated version to 22.1.2 and SHA256
- Disabled `run_constrained` sections (will re-enable in Stage 2)
- Kept `c_compiler_version: 21.1.8` for macOS (bootstrap with old compiler)
- abs.yaml targets `llvm-22.1.2-stage0-build-0` staging channel

Part of PKG-12851 (LLVM 22 epic), child ticket PKG-13330.