### PR TITLE
Update llvmdev to 22.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -11,9 +11,8 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
-channels:
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+# Stage 0: Upload to LLVM 22 staging channel
+staging_channel_upload_target: llvm-22.1.2-stage0-build-0
 
 aggregate_check: false
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -14,5 +14,9 @@ build_parameters:
 # Stage 0: Upload to LLVM 22 staging channel
 staging_channel_upload_target: llvm-22.1.2-stage0-build-0
 
+# LLVM 21 staging needed for libcxx-devel 21.1.8 (bootstrap dep, osx only)
+channels:
+  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+
 aggregate_check: false
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -14,7 +14,10 @@ build_parameters:
 # Stage 0: Upload to LLVM 22 staging channel
 staging_channel_upload_target: llvm-22.1.2-stage0-build-0
 
-# No staging channels needed for Stage 0 — libcxx-devel 21.1.8 is in pkgs/main
+# Stage 0 channel needed for libcxx-devel 22.1.2 (osx/linux only)
+# win-64 will get WARNING but should proceed since libcxx-devel has # [osx] selector
+channels:
+  - https://staging.continuum.io/pbp/llvm-22.1.2-stage0-build-0
 
 aggregate_check: false
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -11,12 +11,10 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Stage 0: Upload to new staging channel (old one had CDN corruption)
-staging_channel_upload_target: llvm22-stage0
-
-# Need libcxx 22.1.2 from staging (run dep on osx)
+# Stage 2: Self-hosted build with LLVM 22
+# All LLVM 22 packages on anaconda.org (bypass PBP staging, SIR-2834)
 channels:
-  - https://staging.continuum.io/pbp/llvm22-stage0
+  - https://conda.anaconda.org/xkong-staging
 
 aggregate_check: false
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -14,9 +14,9 @@ build_parameters:
 # Stage 0: Upload to LLVM 22 staging channel
 staging_channel_upload_target: llvm-22.1.2-stage0-build-0
 
-# LLVM 21 staging needed for libcxx-devel 21.1.8 (bootstrap dep, osx only)
+# Stage 0 channel has libcxx-devel 22.1.2 (built by libcxx-feedstock)
 channels:
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+  - https://staging.continuum.io/pbp/llvm-22.1.2-stage0-build-0
 
 aggregate_check: false
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -14,9 +14,7 @@ build_parameters:
 # Stage 0: Upload to LLVM 22 staging channel
 staging_channel_upload_target: llvm-22.1.2-stage0-build-0
 
-# Stage 0 channel has libcxx-devel 22.1.2 (built by libcxx-feedstock)
-channels:
-  - https://staging.continuum.io/pbp/llvm-22.1.2-stage0-build-0
+# No staging channels needed for Stage 0 — libcxx-devel 21.1.8 is in pkgs/main
 
 aggregate_check: false
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -11,13 +11,8 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Stage 0: Upload to LLVM 22 staging channel
-staging_channel_upload_target: llvm-22.1.2-stage0-build-0
-
-# Stage 0 channel needed for libcxx-devel 22.1.2 (osx/linux only)
-# win-64 will get WARNING but should proceed since libcxx-devel has # [osx] selector
-channels:
-  - https://staging.continuum.io/pbp/llvm-22.1.2-stage0-build-0
+# Stage 0: Upload to new staging channel (old one had CDN corruption)
+staging_channel_upload_target: llvm22-stage0
 
 aggregate_check: false
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -14,5 +14,9 @@ build_parameters:
 # Stage 0: Upload to new staging channel (old one had CDN corruption)
 staging_channel_upload_target: llvm22-stage0
 
+# Need libcxx 22.1.2 from staging (run dep on osx)
+channels:
+  - https://staging.continuum.io/pbp/llvm22-stage0
+
 aggregate_check: false
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,7 +5,7 @@ cxx_compiler:
   - clang_bootstrap            # [osx]
   - vs2022                     # [win]
 
-# Stage 2: Self-hosted build with clang 21 compiler
+# Stage 0: Bootstrap build with clang 21 compiler (update to 22.1.2 in Stage 2)
 c_compiler_version:
   - 21.1.8            # [osx]
 cxx_compiler_version:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,11 +5,11 @@ cxx_compiler:
   - clang_bootstrap            # [osx]
   - vs2022                     # [win]
 
-# Stage 0: Bootstrap build with clang 21 compiler (update to 22.1.2 in Stage 2)
+# Stage 2: Self-hosted build with clang 22 compiler
 c_compiler_version:
-  - 21.1.8            # [osx]
+  - 22.1.2            # [osx]
 cxx_compiler_version:
-  - 21.1.8            # [osx]
+  - 22.1.2            # [osx]
 
 c_stdlib_version:   # [win]
   - 2022.14         # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,12 @@
 {% set major_ver = version.split(".")[0] %}
 {% set tail_ver = version.split(".")[-1] %}
 {% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
-{% set libcxx_devel_ver = version %}
+# Stage 0: use libcxx-devel from pkgs/main (21.1.8) for bootstrap
+# conda-build resolves ALL deps (even # [osx]) on all platforms during finalization
+# libcxx-devel 22.1.2 only exists in staging (no win-64) → fails on Windows
+# libcxx-devel 21.1.8 is in pkgs/main → resolves everywhere
+# Change to `version` in Stage 2 after libcxx-devel 22.1.2 is in pkgs/main
+{% set libcxx_devel_ver = "21.1.8" %}
 
 # as of LLVM 19, we expect an "-rcX" suffix for the release candidates
 {% set extra = "-" ~ tail_ver if tail_ver not in "0123456789" else "" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ source:
     # These tests pass on a dev instance with more resources, but fail on CI.
     - patches/0006-win-disable-orcjittests.patch  # [win]
     - patches/0007-win-disable-ProgramEnvTest.patch  # [win]
+    - patches/0008-win-skip-bb-hash-awk-test.patch  # [win]
 
 build:
   number: 0
@@ -35,7 +36,6 @@ requirements:
     - libcxx-devel   # [osx]
     - m2-sed        # [win]
     - m2-grep       # [win]
-    - m2-gawk       # [win]  # for awk (LLVM 22 tests use it)
     - m2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
     - m2-diffutils  # [win]  # for cmp, diff
     - m2-findutils  # [win]  # for find with -exec

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.1.8" %}
+{% set version = "22.1.2" %}
 {% set major_ver = version.split(".")[0] %}
 {% set tail_ver = version.split(".")[-1] %}
 {% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
@@ -13,7 +13,7 @@ package:
 
 source:
   url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  sha256: 7ba3f2a8d8fda88be18a31d011e8195d3b7f87f9fa92b20c94cba2d7f65b0e3f
+  sha256: a252efd7a4a268d2cc5145b17adcaa82757fdee1d06d748b4c24137807710ecb
   patches:
     - patches/0004-remove-unsupported-intrinsic-test.patch
     - patches/0005-remove-permission-based-unit-tests.patch
@@ -76,11 +76,12 @@ outputs:
         - {{ pin_subpackage("llvm-tools", exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
         - libcxx >={{ cxx_compiler_version }}                           # [osx]
-      run_constrained:
-        - llvm        {{ version }}
-        - llvm-tools  {{ version }}
-        - clang       {{ version }}
-        - clang-tools {{ version }}
+      # Stage 0: run_constrained disabled (re-enable in Stage 2)
+      # run_constrained:
+      #   - llvm        {{ version }}
+      #   - llvm-tools  {{ version }}
+      #   - clang       {{ version }}
+      #   - clang-tools {{ version }}
     test:
       requires:
         - ripgrep  # [win]
@@ -148,11 +149,12 @@ outputs:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
       run:                                                            # [not win]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
-      run_constrained:
-        - llvmdev     {{ version }}
-        - llvm-tools  {{ version }}
-        - clang       {{ version }}
-        - clang-tools {{ version }}
+      # Stage 0: run_constrained disabled (re-enable in Stage 2)
+      # run_constrained:
+      #   - llvmdev     {{ version }}
+      #   - llvm-tools  {{ version }}
+      #   - clang       {{ version }}
+      #   - clang-tools {{ version }}
     test:
       commands:
         - echo "Hello World!"
@@ -217,11 +219,12 @@ outputs:
       run:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
-      run_constrained:
-        - llvm        {{ version }}
-        - llvmdev     {{ version }}
-        - clang       {{ version }}
-        - clang-tools {{ version }}
+      # Stage 0: run_constrained disabled (re-enable in Stage 2)
+      # run_constrained:
+      #   - llvm        {{ version }}
+      #   - llvmdev     {{ version }}
+      #   - clang       {{ version }}
+      #   - clang-tools {{ version }}
     test:
       commands:
         - $PREFIX/bin/llc -version                               # [not win]
@@ -256,8 +259,9 @@ outputs:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - zlib {{ zlib }}
         - zstd {{ zstd }}
-      run_constrained:
-        - llvmdev {{ version }}
+      # Stage 0: run_constrained disabled (re-enable in Stage 2)
+      # run_constrained:
+      #   - llvmdev {{ version }}
     test:
       commands:
         - test -f $PREFIX/lib/libLLVM-C.{{ major_ver }}.dylib   # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,10 +2,7 @@
 {% set major_ver = version.split(".")[0] %}
 {% set tail_ver = version.split(".")[-1] %}
 {% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
-# Stage 0: pin libcxx-devel to old LLVM version for bootstrap
-# Jinja renders before selectors, so this must be valid on all platforms
-# Change to `version` in Stage 2 for self-hosted build
-{% set libcxx_devel_ver = "21.1.8" %}
+{% set libcxx_devel_ver = version %}
 
 # as of LLVM 19, we expect an "-rcX" suffix for the release candidates
 {% set extra = "-" ~ tail_ver if tail_ver not in "0123456789" else "" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ source:
     - patches/0005-remove-permission-based-unit-tests.patch
     # These tests pass on a dev instance with more resources, but fail on CI.
     - patches/0006-win-disable-orcjittests.patch  # [win]
+    - patches/0007-win-disable-ProgramEnvTest.patch  # [win]
 
 build:
   number: 0
@@ -34,6 +35,7 @@ requirements:
     - libcxx-devel   # [osx]
     - m2-sed        # [win]
     - m2-grep       # [win]
+    - m2-gawk       # [win]  # for awk (LLVM 22 tests use it)
     - m2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
     - m2-diffutils  # [win]  # for cmp, diff
     - m2-findutils  # [win]  # for find with -exec

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,8 @@
 {% set major_ver = version.split(".")[0] %}
 {% set tail_ver = version.split(".")[-1] %}
 {% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
+# Stage 0: pin libcxx-devel to old version (Jinja renders before selectors, so need default for non-osx)
+{% set libcxx_devel_ver = cxx_compiler_version | default(version) %}
 
 # as of LLVM 19, we expect an "-rcX" suffix for the release candidates
 {% set extra = "-" ~ tail_ver if tail_ver not in "0123456789" else "" %}
@@ -31,7 +33,7 @@ requirements:
     - cmake
     - ninja
     - python
-    - libcxx-devel {{ cxx_compiler_version }}    # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+    - libcxx-devel {{ libcxx_devel_ver }}    # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
     - m2-sed        # [win]
     - m2-grep       # [win]
     - m2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
@@ -43,7 +45,7 @@ requirements:
     - libxml2 {{ libxml2 }}
     - zlib {{ zlib }}
     - zstd {{ zstd }}
-    - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+    - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
 
 outputs:
   # Contains everything
@@ -62,9 +64,9 @@ outputs:
         - ninja
         - python
         - m2-sed                  # [win]
-        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
       host:
-        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("libllvm-c" ~ major_ver, exact=True) }}     # [win]
         - {{ pin_subpackage("llvm-tools", exact=True) }}
@@ -75,7 +77,7 @@ outputs:
         - {{ pin_subpackage("libllvm-c" ~ major_ver, exact=True) }}     # [win]
         - {{ pin_subpackage("llvm-tools", exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
-        - libcxx >={{ cxx_compiler_version }}                           # [osx]
+        - libcxx >={{ libcxx_devel_ver }}                           # [osx]
       # Stage 0: run_constrained disabled (re-enable in Stage 2)
       # run_constrained:
       #   - llvm        {{ version }}
@@ -115,15 +117,15 @@ outputs:
         - ninja                    # [not win]
         - cmake                    # [not win]
         - python                   # [not win]
-        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
       host:
-        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
         - libxml2 {{ libxml2 }} # [unix]
         - zlib {{ zlib }}
         - zstd {{ zstd }}
       run:
         # we need to do this manually because clang_bootstrap has no run-export
-        - libcxx >={{ cxx_compiler_version }}  # [osx]
+        - libcxx >={{ libcxx_devel_ver }}  # [osx]
     test:
       commands:
         # old style
@@ -175,16 +177,16 @@ outputs:
         - cmake
         - ninja
         - python >=3
-        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
       host:
-        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - zlib
         - zstd
       run:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
-        - libcxx >={{ cxx_compiler_version }}  # [osx]
+        - libcxx >={{ libcxx_devel_ver }}  # [osx]
     test:
       commands:
         - $PREFIX/bin/llc-{{ major_ver }} -version                               # [not win]
@@ -208,7 +210,7 @@ outputs:
         - cmake
         - ninja
         - python
-        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
       host:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
@@ -253,9 +255,9 @@ outputs:
         - {{ stdlib('c') }}
         - cmake
         - ninja
-        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
       host:
-        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
+        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - zlib {{ zlib }}
         - zstd {{ zstd }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,12 +78,11 @@ outputs:
         - {{ pin_subpackage("llvm-tools", exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
         - libcxx >={{ version }}                           # [osx]
-      # Stage 0: run_constrained disabled (re-enable in Stage 2)
-      # run_constrained:
-      #   - llvm        {{ version }}
-      #   - llvm-tools  {{ version }}
-      #   - clang       {{ version }}
-      #   - clang-tools {{ version }}
+      run_constrained:
+        - llvm        {{ version }}
+        - llvm-tools  {{ version }}
+        - clang       {{ version }}
+        - clang-tools {{ version }}
     test:
       requires:
         - ripgrep  # [win]
@@ -151,12 +150,11 @@ outputs:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
       run:                                                            # [not win]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}     # [not win]
-      # Stage 0: run_constrained disabled (re-enable in Stage 2)
-      # run_constrained:
-      #   - llvmdev     {{ version }}
-      #   - llvm-tools  {{ version }}
-      #   - clang       {{ version }}
-      #   - clang-tools {{ version }}
+      run_constrained:
+        - llvmdev     {{ version }}
+        - llvm-tools  {{ version }}
+        - clang       {{ version }}
+        - clang-tools {{ version }}
     test:
       commands:
         - echo "Hello World!"
@@ -221,12 +219,11 @@ outputs:
       run:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
-      # Stage 0: run_constrained disabled (re-enable in Stage 2)
-      # run_constrained:
-      #   - llvm        {{ version }}
-      #   - llvmdev     {{ version }}
-      #   - clang       {{ version }}
-      #   - clang-tools {{ version }}
+      run_constrained:
+        - llvm        {{ version }}
+        - llvmdev     {{ version }}
+        - clang       {{ version }}
+        - clang-tools {{ version }}
     test:
       commands:
         - $PREFIX/bin/llc -version                               # [not win]
@@ -261,9 +258,8 @@ outputs:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - zlib {{ zlib }}
         - zstd {{ zstd }}
-      # Stage 0: run_constrained disabled (re-enable in Stage 2)
-      # run_constrained:
-      #   - llvmdev {{ version }}
+      run_constrained:
+        - llvmdev {{ version }}
     test:
       commands:
         - test -f $PREFIX/lib/libLLVM-C.{{ major_ver }}.dylib   # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - cmake
     - ninja
     - python
-    - libcxx-devel {{ version }}    # [osx]
+    - libcxx-devel {{ cxx_compiler_version }}    # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
     - m2-sed        # [win]
     - m2-grep       # [win]
     - m2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
@@ -43,7 +43,7 @@ requirements:
     - libxml2 {{ libxml2 }}
     - zlib {{ zlib }}
     - zstd {{ zstd }}
-    - libcxx-devel {{ version }}  # [osx]
+    - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
 
 outputs:
   # Contains everything
@@ -62,9 +62,9 @@ outputs:
         - ninja
         - python
         - m2-sed                  # [win]
-        - libcxx-devel {{ version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
       host:
-        - libcxx-devel {{ version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("libllvm-c" ~ major_ver, exact=True) }}     # [win]
         - {{ pin_subpackage("llvm-tools", exact=True) }}
@@ -115,9 +115,9 @@ outputs:
         - ninja                    # [not win]
         - cmake                    # [not win]
         - python                   # [not win]
-        - libcxx-devel {{ version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
       host:
-        - libcxx-devel {{ version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
         - libxml2 {{ libxml2 }} # [unix]
         - zlib {{ zlib }}
         - zstd {{ zstd }}
@@ -175,9 +175,9 @@ outputs:
         - cmake
         - ninja
         - python >=3
-        - libcxx-devel {{ version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
       host:
-        - libcxx-devel {{ version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - zlib
         - zstd
@@ -208,7 +208,7 @@ outputs:
         - cmake
         - ninja
         - python
-        - libcxx-devel {{ version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
       host:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
@@ -253,9 +253,9 @@ outputs:
         - {{ stdlib('c') }}
         - cmake
         - ninja
-        - libcxx-devel {{ version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
       host:
-        - libcxx-devel {{ version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]  # Stage 0: use old libcxx (change to {{ version }} in Stage 2)
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - zlib {{ zlib }}
         - zstd {{ zstd }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,12 +2,6 @@
 {% set major_ver = version.split(".")[0] %}
 {% set tail_ver = version.split(".")[-1] %}
 {% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
-# Stage 0: use libcxx-devel from pkgs/main (21.1.8) for bootstrap
-# conda-build resolves ALL deps (even # [osx]) on all platforms during finalization
-# libcxx-devel 22.1.2 only exists in staging (no win-64) → fails on Windows
-# libcxx-devel 21.1.8 is in pkgs/main → resolves everywhere
-# Change to `version` in Stage 2 after libcxx-devel 22.1.2 is in pkgs/main
-{% set libcxx_devel_ver = "21.1.8" %}
 
 # as of LLVM 19, we expect an "-rcX" suffix for the release candidates
 {% set extra = "-" ~ tail_ver if tail_ver not in "0123456789" else "" %}
@@ -37,7 +31,7 @@ requirements:
     - cmake
     - ninja
     - python
-    - libcxx-devel {{ libcxx_devel_ver }}    # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+    - libcxx-devel   # [osx]
     - m2-sed        # [win]
     - m2-grep       # [win]
     - m2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
@@ -49,7 +43,7 @@ requirements:
     - libxml2 {{ libxml2 }}
     - zlib {{ zlib }}
     - zstd {{ zstd }}
-    - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+    - libcxx-devel   # [osx]
 
 outputs:
   # Contains everything
@@ -68,9 +62,9 @@ outputs:
         - ninja
         - python
         - m2-sed                  # [win]
-        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+        - libcxx-devel   # [osx]
       host:
-        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+        - libcxx-devel   # [osx]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("libllvm-c" ~ major_ver, exact=True) }}     # [win]
         - {{ pin_subpackage("llvm-tools", exact=True) }}
@@ -81,7 +75,7 @@ outputs:
         - {{ pin_subpackage("libllvm-c" ~ major_ver, exact=True) }}     # [win]
         - {{ pin_subpackage("llvm-tools", exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
-        - libcxx >={{ libcxx_devel_ver }}                           # [osx]
+        - libcxx >={{ version }}                           # [osx]
       # Stage 0: run_constrained disabled (re-enable in Stage 2)
       # run_constrained:
       #   - llvm        {{ version }}
@@ -121,15 +115,15 @@ outputs:
         - ninja                    # [not win]
         - cmake                    # [not win]
         - python                   # [not win]
-        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+        - libcxx-devel   # [osx]
       host:
-        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+        - libcxx-devel   # [osx]
         - libxml2 {{ libxml2 }} # [unix]
         - zlib {{ zlib }}
         - zstd {{ zstd }}
       run:
         # we need to do this manually because clang_bootstrap has no run-export
-        - libcxx >={{ libcxx_devel_ver }}  # [osx]
+        - libcxx >={{ version }}  # [osx]
     test:
       commands:
         # old style
@@ -181,16 +175,16 @@ outputs:
         - cmake
         - ninja
         - python >=3
-        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+        - libcxx-devel   # [osx]
       host:
-        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+        - libcxx-devel   # [osx]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - zlib
         - zstd
       run:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         # we need to do this manually because clang_bootstrap has no run-export
-        - libcxx >={{ libcxx_devel_ver }}  # [osx]
+        - libcxx >={{ version }}  # [osx]
     test:
       commands:
         - $PREFIX/bin/llc-{{ major_ver }} -version                               # [not win]
@@ -214,7 +208,7 @@ outputs:
         - cmake
         - ninja
         - python
-        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+        - libcxx-devel   # [osx]
       host:
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - {{ pin_subpackage("llvm-tools-" ~ major_ver, exact=True) }}   # [not win]
@@ -259,9 +253,9 @@ outputs:
         - {{ stdlib('c') }}
         - cmake
         - ninja
-        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+        - libcxx-devel   # [osx]
       host:
-        - libcxx-devel {{ libcxx_devel_ver }}  # [osx]  # Stage 0: uses cxx_compiler_version (change to {{ version }} in Stage 2)
+        - libcxx-devel   # [osx]
         - {{ pin_subpackage("libllvm" ~ major_ver, exact=True) }}
         - zlib {{ zlib }}
         - zstd {{ zstd }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,8 +2,10 @@
 {% set major_ver = version.split(".")[0] %}
 {% set tail_ver = version.split(".")[-1] %}
 {% set maj_min = major_ver ~ "." ~ version.split(".")[1] %}
-# Stage 0: pin libcxx-devel to old version (Jinja renders before selectors, so need default for non-osx)
-{% set libcxx_devel_ver = cxx_compiler_version | default(version) %}
+# Stage 0: pin libcxx-devel to old LLVM version for bootstrap
+# Jinja renders before selectors, so this must be valid on all platforms
+# Change to `version` in Stage 2 for self-hosted build
+{% set libcxx_devel_ver = "21.1.8" %}
 
 # as of LLVM 19, we expect an "-rcX" suffix for the release candidates
 {% set extra = "-" ~ tail_ver if tail_ver not in "0123456789" else "" %}

--- a/recipe/patches/0007-win-disable-ProgramEnvTest.patch
+++ b/recipe/patches/0007-win-disable-ProgramEnvTest.patch
@@ -1,0 +1,27 @@
+From: Xianglong Kong <xkong@anaconda.com>
+Date: Mon, 31 Mar 2026
+Subject: [PATCH] Disable ProgramEnvTest.TestExecuteEmptyEnvironment on Windows
+
+This test fails on Windows CI with STATUS_DLL_NOT_FOUND (0xC0000135)
+when running a program with an empty environment, because essential
+DLLs cannot be loaded without proper PATH in the environment.
+
+Index: llvm-project/llvm/unittests/Support/ProgramTest.cpp
+===================================================================
+--- llvm-project.orig/llvm/unittests/Support/ProgramTest.cpp
++++ llvm-project/llvm/unittests/Support/ProgramTest.cpp
+@@ -695,6 +695,7 @@ TEST(ProgramEnvTest, TestExecuteAndWaitT
+   ASSERT_GT(SecondsElapsed.count(), 0);
+ }
+
++#if !defined(_WIN32)
+ TEST(ProgramEnvTest, TestExecuteEmptyEnvironment) {
+   std::string Executable =
+       sys::FindProgramByName(TestMainArgv0).get();
+@@ -705,5 +706,6 @@ TEST(ProgramEnvTest, TestExecuteEmptyEnv
+   ASSERT_EQ(0, RetCode);
+ }
+
++#endif
+
+ } // end anonymous namespace

--- a/recipe/patches/0007-win-disable-ProgramEnvTest.patch
+++ b/recipe/patches/0007-win-disable-ProgramEnvTest.patch
@@ -10,17 +10,17 @@ Index: llvm-project/llvm/unittests/Support/ProgramTest.cpp
 ===================================================================
 --- llvm-project.orig/llvm/unittests/Support/ProgramTest.cpp
 +++ llvm-project/llvm/unittests/Support/ProgramTest.cpp
-@@ -680,6 +680,7 @@
+@@ -680,6 +680,7 @@ TEST_F(ProgramEnvTest, TestExecuteWithNo
    ASSERT_EQ(0, RetCode);
  }
 
 +#if !defined(_WIN32)
  TEST_F(ProgramEnvTest, TestExecuteEmptyEnvironment) {
-   std::string Executable =
-       sys::FindProgramByName(TestMainArgv0).get();
-@@ -704,5 +705,6 @@
+   using namespace llvm::sys;
+
+@@ -705,4 +706,5 @@ TEST_F(ProgramEnvTest, TestExecuteEmptyE
  #endif
  }
 
-+#endif
++#endif  // !defined(_WIN32)
  } // end anonymous namespace

--- a/recipe/patches/0007-win-disable-ProgramEnvTest.patch
+++ b/recipe/patches/0007-win-disable-ProgramEnvTest.patch
@@ -1,5 +1,5 @@
 From: Xianglong Kong <xkong@anaconda.com>
-Date: Mon, 31 Mar 2026
+Date: Tue, 01 Apr 2026
 Subject: [PATCH] Disable ProgramEnvTest.TestExecuteEmptyEnvironment on Windows
 
 This test fails on Windows CI with STATUS_DLL_NOT_FOUND (0xC0000135)
@@ -10,18 +10,17 @@ Index: llvm-project/llvm/unittests/Support/ProgramTest.cpp
 ===================================================================
 --- llvm-project.orig/llvm/unittests/Support/ProgramTest.cpp
 +++ llvm-project/llvm/unittests/Support/ProgramTest.cpp
-@@ -695,6 +695,7 @@ TEST(ProgramEnvTest, TestExecuteAndWaitT
-   ASSERT_GT(SecondsElapsed.count(), 0);
- }
-
-+#if !defined(_WIN32)
- TEST(ProgramEnvTest, TestExecuteEmptyEnvironment) {
-   std::string Executable =
-       sys::FindProgramByName(TestMainArgv0).get();
-@@ -705,5 +706,6 @@ TEST(ProgramEnvTest, TestExecuteEmptyEnv
+@@ -680,6 +680,7 @@
    ASSERT_EQ(0, RetCode);
  }
 
-+#endif
++#if !defined(_WIN32)
+ TEST_F(ProgramEnvTest, TestExecuteEmptyEnvironment) {
+   std::string Executable =
+       sys::FindProgramByName(TestMainArgv0).get();
+@@ -704,5 +705,6 @@
+ #endif
+ }
 
++#endif
  } // end anonymous namespace

--- a/recipe/patches/0008-win-skip-bb-hash-awk-test.patch
+++ b/recipe/patches/0008-win-skip-bb-hash-awk-test.patch
@@ -11,6 +11,6 @@ Index: llvm-project/llvm/test/CodeGen/X86/basic-block-sections-clusters-bb-hash.
 +++ llvm-project/llvm/test/CodeGen/X86/basic-block-sections-clusters-bb-hash.ll
 @@ -1,3 +1,4 @@
 +; UNSUPPORTED: system-windows
- ;; This test is to check if the bb-hash is emitted correctly when bb-clusters
- ;; are being used to reorder basic blocks.
- ;;
+ ; BB cluster section tests when using edges profile and basic blocks hashes to generate clusters.
+ ; In the tests, we first generate hash values for basic blocks and write them to the profile.
+ ; When generating basic blocks clusters, we match the hashes of basic blocks in the current CFG

--- a/recipe/patches/0008-win-skip-bb-hash-awk-test.patch
+++ b/recipe/patches/0008-win-skip-bb-hash-awk-test.patch
@@ -1,0 +1,16 @@
+From: Xianglong Kong <xkong@anaconda.com>
+Date: Tue, 01 Apr 2026
+Subject: [PATCH] Skip bb-hash test that requires awk on Windows
+
+The basic-block-sections-clusters-bb-hash.ll test uses awk which is not
+available on Windows CI. Mark it as UNSUPPORTED on Windows.
+
+Index: llvm-project/llvm/test/CodeGen/X86/basic-block-sections-clusters-bb-hash.ll
+===================================================================
+--- llvm-project.orig/llvm/test/CodeGen/X86/basic-block-sections-clusters-bb-hash.ll
++++ llvm-project/llvm/test/CodeGen/X86/basic-block-sections-clusters-bb-hash.ll
+@@ -1,3 +1,4 @@
++; UNSUPPORTED: system-windows
+ ;; This test is to check if the bb-hash is emitted correctly when bb-clusters
+ ;; are being used to reorder basic blocks.
+ ;;


### PR DESCRIPTION
llvmdev 22.1.2

**Destination channel:** defaults

### Links

- [PKG-13330](https://anaconda.atlassian.net/browse/PKG-13330)
- [PKG-12851](https://anaconda.atlassian.net/browse/PKG-12851) (LLVM 22 epic)
- [Upstream repository](https://github.com/llvm/llvm-project)
- [Upstream changelog/diff](https://releases.llvm.org/22.1.0/docs/ReleaseNotes.html)

### Explanation of changes:

- Updated version from 21.1.8 to 22.1.2 and SHA256
- Stage 2: self-hosted build with clang 22 compiler (`c_compiler_version: 22.1.2`)
- `libcxx-devel` left unversioned on `# [osx]` lines (conda-build 26.x resolves platform-specific deps on all platforms during finalization — versioned pin fails on win-64)
- New patches for LLVM 22: `0007-win-disable-ProgramEnvTest.patch`, `0008-win-skip-bb-hash-awk-test.patch`
- abs.yaml uses `xkong-staging` channel for LLVM 22 dependencies

**Note:** This PR uses `https://conda.anaconda.org/xkong-staging` instead of PBP staging channels because PBP staging corrupts large files (>400MB) during download — see [SIR-2834](https://anaconda.atlassian.net/browse/SIR-2834). All LLVM 22 packages were downloaded from TaskCluster artifacts and uploaded to `xkong-staging` on anaconda.org as a workaround. This channel reference should be removed after packages are promoted to pkgs/main.

[PKG-13330]: https://anaconda.atlassian.net/browse/PKG-13330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-12851]: https://anaconda.atlassian.net/browse/PKG-12851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIR-2834]: https://anaconda.atlassian.net/browse/SIR-2834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ