### PR TITLE
Rebuild against libxml2 2.14

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -7,7 +7,5 @@ extra_labels_for_os:
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/libxml2-feedstock/pr25/58bfcbc
 
 aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -7,7 +7,6 @@ extra_labels_for_os:
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"
 channels:
   - https://staging.continuum.io/preprod-pbp/fs/libxml2-feedstock/pr25/58bfcbc
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,6 +4,9 @@
 extra_labels_for_os:
   osx-arm64: [ventura]
 
+# Extend timeout to 6 hours (21600 seconds) for Windows builds
+task_timeout: 21600
+
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -8,5 +8,7 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
   - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/libxml2-feedstock/pr25/58bfcbc
 
 aggregate_check: false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -15,3 +15,5 @@ c_stdlib_version:   # [win]
 
 libxml2:
   - 2.14.4
+libffi:
+  - 3.4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,3 +12,6 @@ cxx_compiler_version:
 
 c_stdlib_version:   # [win]
   - 2022.14         # [win]
+
+libxml2:
+  - 2.14.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,11 @@ requirements:
     - ninja
     - python
     - libcxx-devel {{ version }}    # [osx]
-    - m2-sed  # [win]
+    - m2-sed        # [win]
+    - m2-grep       # [win]
+    - m2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
+    - m2-diffutils  # [win]  # for cmp, diff
+    - m2-findutils  # [win]  # for find with -exec
     - git
   host:
     - backtrace {{ backtrace }}         # [unix]
@@ -58,6 +62,7 @@ outputs:
         - ninja
         - python
         - m2-sed                  # [win]
+        - m2-base                 # [win]
         - libcxx-devel {{ version }}  # [osx]
       host:
         - libcxx-devel {{ version }}  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - patches/0006-win-disable-orcjittests.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   merge_build_host: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - python
     - libcxx-devel {{ version }}    # [osx]
     - m2-sed  # [win]
-    - git     # [not win]
+    - git
   host:
     - backtrace {{ backtrace }}         # [unix]
     - libxml2 {{ libxml2 }}


### PR DESCRIPTION
llvmdev 20.1.8

**Destination channel:**  defaults

### Links

- [PKG-12512](https://anaconda.atlassian.net/browse/PKG-12512) 
- [Upstream repository](https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8)

### Explanation of changes:
- New build number
- Update version of libxml2


[PKG-12512]: https://anaconda.atlassian.net/browse/PKG-12512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ