### PR TITLE
Rebuild against libxml2 2.14

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -14,6 +14,7 @@ build_parameters:
 # Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
 channels:
   - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
+  - https://staging.continuum.io/preprod-pbp/fs/libxml2-feedstock/pr25/58bfcbc
 
 aggregate_check: false
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -14,7 +14,6 @@ build_parameters:
 # Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
 channels:
   - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
-  - https://staging.continuum.io/preprod-pbp/fs/libxml2-feedstock/pr25/58bfcbc
 
 aggregate_check: false
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -11,9 +11,5 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
-channels:
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
-
 aggregate_check: false
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -17,3 +17,5 @@ c_stdlib_version:   # [win]
 # Required for PBP - not included in Python-variant task CBCs
 libffi:
   - '3.4'
+libxml2:
+  - 2.14.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - patches/0006-win-disable-orcjittests.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   merge_build_host: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - m2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
     - m2-diffutils  # [win]  # for cmp, diff
     - m2-findutils  # [win]  # for find with -exec
-    - git     # [not win]
+    - git
   host:
     - backtrace {{ backtrace }}         # [unix]
     - libxml2 {{ libxml2 }}


### PR DESCRIPTION
llvmdev 21.1.8

**Destination channel:** defaults

### Links

- [PKG-12512](https://anaconda.atlassian.net/browse/PKG-12512) 
- [Upstream repository](https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8)

### Explanation of changes:
- New build number
- Update libxml2 version


[PKG-12512]: https://anaconda.atlassian.net/browse/PKG-12512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ