### PR TITLE
Rebuild against libxml2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -17,3 +17,5 @@ c_stdlib_version:   # [win]
 # Required for PBP - not included in Python-variant task CBCs
 libffi:
   - '3.4'
+libxml2:
+  - 2.14.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/0008-win-skip-bb-hash-awk-test.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   merge_build_host: false
 
 requirements:


### PR DESCRIPTION
llvmdev 22.1.2

**Destination channel:** defaults

### Links

- [PKG-14710](https://anaconda.atlassian.net/browse/PKG-14710) 
- [Upstream repository](https://github.com/llvm/llvm-project/tree/llvmorg-22.1.3)

### Explanation of changes:
- Rebuild against libxml2


[PKG-14710]: https://anaconda.atlassian.net/browse/PKG-14710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ