### PR TITLE
PKG-15270: llvmdev 17.0.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,13 +1,2 @@
-# Four unit tests crash on big sur builders, but not ventura.
-# These tests call /usr/lib/system/libsystem_pthread.dylib
-# before crashing.
-extra_labels_for_os:
-  osx-arm64: [ventura]
 
-# the conda build parameters to use
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-17.0.6-stage2-attempt-4"
-
-aggregate_check: false
+task_timeout: 120000

--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,4 @@
+anaconda_config_version: 1
+upstream_sources:
+  - pypi:
+      identifier: llvmdev

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -57,6 +57,7 @@ set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|tools/llvm-pdbutil/symbol-filters.test"
 set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|tools/llvm-pdbutil/type-qualifiers.test"
 set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|tools/llvm-pdbutil/usingnamespace.test"
 set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|tools/llvm-symbolizer/pdb/pdb.test"
+set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|tools/llvm-nm/just-symbols.test"
 
 cmake --build . --target check-llvm
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,20 +26,20 @@ source:
     # # - patches/MSVC_DIA_SDK_path_fix.diff  # [win]
 
 build:
-  number: 4
+  number: 7
   merge_build_host: false
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - cmake
-    - ninja
+    - ninja-base
     - python
     - libcxx-devel {{ bootstrap_version }}    # [osx]
-    - patch                     # [not win]
-    - m2-patch                  # [win]
-    - m2-sed                    # [win]
-    - git                       # [not win]
+    - msys2-sed                    # [win]
+    - git
+    - yaml  # [win]
   host:
     - libcxx-devel {{ bootstrap_version }}    # [osx]
     - backtrace {{ backtrace }}         # [unix]
@@ -47,6 +47,7 @@ requirements:
     - libxml2 {{ libxml2 }}
     - zlib {{ zlib }}
     - zstd {{ zstd }}
+    - pygments  # [win]
 
 outputs:
   # Contains everything
@@ -60,11 +61,12 @@ outputs:
       #   - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
         - cmake
-        - ninja
+        - ninja-base
         - python
-        - m2-sed                  # [win]
+        - msys2-sed                  # [win]
         - libcxx-devel {{ bootstrap_version }}  # [osx]
       host:
         - libcxx-devel {{ bootstrap_version }}  # [osx]
@@ -110,8 +112,9 @@ outputs:
         - {{ pin_subpackage("libllvm" + major_ver, max_pin="x.x") }}  # [not win]
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
-        - ninja                    # [not win]
+        - ninja-base               # [not win]
         - cmake                    # [not win]
         - python                   # [not win]
         - libcxx-devel {{ bootstrap_version }}  # [osx]
@@ -171,9 +174,10 @@ outputs:
       #   - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
         - cmake
-        - ninja
+        - ninja-base
         - python
         - libcxx-devel {{ bootstrap_version }}  # [osx]
       host:
@@ -215,16 +219,17 @@ outputs:
       skip: true  # [not win]
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
         - cmake
-        - ninja
+        - ninja-base
         - libcxx {{ cxx_compiler_version }}  # [osx]
       host:
         - libcxx {{ cxx_compiler_version }}  # [osx]
         - {{ pin_subpackage("libllvm" + major_ver, exact=True) }}
-        - libxml2
-        - zlib
-        - zstd
+        - libxml2 {{ libxml2 }}
+        - zlib {{ zlib }}
+        - zstd {{ zstd }}
       run_constrained:
         - llvmdev {{ version }}
     test:
@@ -274,6 +279,8 @@ extra:
     # for some of the individual outputs.
     - missing_tests
     - wrong_output_script_key
+    - should_use_compilers
+    - missing_pip_check
   recipe-maintainers:
     - JohanMabille
     - inducer


### PR DESCRIPTION
llvmdev 17.0.6

**Destination channel:** defaults

### Links

- [PKG-15270](https://anaconda.atlassian.net/browse/PKG-15270) 
- [llvmdev-feedstock](https://github.com/AnacondaRecipes/llvmdev-feedstock)


### Explanation of changes:

- rebuild llvmdev 17 against libxml2 2.14


[PKG-15270]: https://anaconda.atlassian.net/browse/PKG-15270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ