### PR TITLE
llvm-22 rebuild for win-arm64

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -6,15 +6,3 @@ extra_labels_for_os:
 
 # Extend timeout to 6 hours (21600 seconds) for Windows builds
 task_timeout: 21600
-
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-
-# Stage 2: Self-hosted build with LLVM 22
-# All LLVM 22 packages on anaconda.org (bypass PBP staging, SIR-2834)
-channels:
-  - https://conda.anaconda.org/xkong-staging
-
-aggregate_check: false
-

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -58,6 +58,17 @@ set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|tools/llvm-pdbutil/type-qualifiers.test"
 set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|tools/llvm-pdbutil/usingnamespace.test"
 set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|tools/llvm-symbolizer/pdb/pdb.test"
 
+REM lli -jit-kind=orc crashes with 0xc0000005 on Windows (see patches/0006-win-disable-orcjittests.patch).
+set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|ExecutionEngine/Orc/"
+
+REM llvm-jitlistener produces no output without Intel VTune/ittnotify collector (win-64 only; disabled on win-arm64).
+if /I not "%TARGET_PLATFORM%"=="win-arm64" set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|JitListener/"
+
+REM s390x cross-target codegen emits larl constant-pool loads on Windows; FileCheck expects Linux output.
+set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|CodeGen/SystemZ/rot-03.ll"
+set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|CodeGen/SystemZ/shift-17.ll"
+set "LIT_FILTER_OUT=%LIT_FILTER_OUT%|CodeGen/SystemZ/store_nonbytesized_vecs.ll"
+
 cmake --build . --target check-llvm
 if %ERRORLEVEL% neq 0 exit 1
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,9 +13,3 @@ cxx_compiler_version:
 
 c_stdlib_version:   # [win]
   - 2022.14         # [win]
-
-# Required for PBP - not included in Python-variant task CBCs
-libffi:
-  - '3.4'
-libxml2:
-  - 2.14.4

--- a/recipe/install_llvm.bat
+++ b/recipe/install_llvm.bat
@@ -32,9 +32,9 @@ if "%PKG_NAME%" == "libllvm-c%PKG_VERSION:~0,2%" (
     REM https://github.com/llvm/llvm-project/blob/llvmorg-14.0.6/llvm/cmake/config-ix.cmake#L516
     REM and gets hardcoded by CMake to point to the path in our windows image.
     REM This makes it non-portable between image versions (e.g. 2019 vs 2022), so replace
-    REM the hardcoded path with a variable again
-    REM Updated to remove any assumptions about the edition or version of Visual Studio
-    sed -i "s,[^\";]*DIA SDK/lib/amd64/diaguids\.lib,^$ENV{VSINSTALLDIR}/DIA SDK/lib/amd64/diaguids\.lib,g" %LIBRARY_LIB%\cmake\llvm\LLVMExports.cmake
+    REM the hardcoded path with a variable again, preserving the arch-specific lib subdir
+    REM (amd64 on win-64, arm64 on win-arm64).
+    sed -i "s,[^\";]*DIA SDK/lib/\([^/]*\)/diaguids\.lib,^$ENV{VSINSTALLDIR}/DIA SDK/lib/\1/diaguids\.lib,g" %LIBRARY_LIB%\cmake\llvm\LLVMExports.cmake
 )
 
 rmdir /s /q temp_prefix

--- a/recipe/install_llvm.bat
+++ b/recipe/install_llvm.bat
@@ -34,7 +34,8 @@ if "%PKG_NAME%" == "libllvm-c%PKG_VERSION:~0,2%" (
     REM This makes it non-portable between image versions (e.g. 2019 vs 2022), so replace
     REM the hardcoded path with a variable again, preserving the arch-specific lib subdir
     REM (amd64 on win-64, arm64 on win-arm64).
-    sed -i "s,[^"";]*DIA SDK/lib/\([^/]*\)/diaguids\.lib,^$ENV{VSINSTALLDIR}/DIA SDK/lib/\1/diaguids\.lib,g" %LIBRARY_LIB%\cmake\llvm\LLVMExports.cmake
+    REM Use | as sed delimiter to avoid batch quoting issues with ; and " in the pattern.
+    sed -i "s|[^"";]*DIA SDK/lib/\([^/]*\)/diaguids\.lib|$ENV{VSINSTALLDIR}/DIA SDK/lib/\1/diaguids\.lib|g" %LIBRARY_LIB%\cmake\llvm\LLVMExports.cmake
 )
 
 rmdir /s /q temp_prefix

--- a/recipe/install_llvm.bat
+++ b/recipe/install_llvm.bat
@@ -34,7 +34,7 @@ if "%PKG_NAME%" == "libllvm-c%PKG_VERSION:~0,2%" (
     REM This makes it non-portable between image versions (e.g. 2019 vs 2022), so replace
     REM the hardcoded path with a variable again, preserving the arch-specific lib subdir
     REM (amd64 on win-64, arm64 on win-arm64).
-    sed -i "s,[^\";]*DIA SDK/lib/\([^/]*\)/diaguids\.lib,^$ENV{VSINSTALLDIR}/DIA SDK/lib/\1/diaguids\.lib,g" %LIBRARY_LIB%\cmake\llvm\LLVMExports.cmake
+    sed -i "s,[^"";]*DIA SDK/lib/\([^/]*\)/diaguids\.lib,^$ENV{VSINSTALLDIR}/DIA SDK/lib/\1/diaguids\.lib,g" %LIBRARY_LIB%\cmake\llvm\LLVMExports.cmake
 )
 
 rmdir /s /q temp_prefix

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/0008-win-skip-bb-hash-awk-test.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   merge_build_host: false
 
 requirements:
@@ -98,7 +98,7 @@ outputs:
         - llvm-nm.exe --help                                            # [win]
 
         # ensure we've correctly inserted %VSINSTALLDIR% into the CMake metadata for LLVM;
-        # we're looking for: `INTERFACE_LINK_LIBRARIES "$ENV{VSINSTALLDIR}/DIA SDK/lib/amd64/diaguids.lib;[...]`instead
+        # we're looking for: `INTERFACE_LINK_LIBRARIES "$ENV{VSINSTALLDIR}/DIA SDK/lib/{amd64,arm64}/diaguids.lib;[...]"`
         - rg -e "INTERFACE_LINK_LIBRARIES\s\"\$ENV\{VSINSTALLDIR\}[/\w\s]+/diaguids\.lib" %LIBRARY_LIB%\cmake\llvm\LLVMExports.cmake  # [win]
 
   # Contains the shared libraries. To make different LLVM libraries co-installable


### PR DESCRIPTION
llvmdev rebuild fixing win-arm64

**Destination channel:** default

### Links

- [PKG-15379](https://anaconda.atlassian.net/browse/PKG-15379) 

### Explanation of changes:

- Bump build number
- Add additional test skips to support win-arm64
- Cleanup local cbc
- Cleanup abs.yaml
- Fix sed command on windows

### Notes
- The one win-64 test that shows as running in PBP actually finished successfully. 


[PKG-15379]: https://anaconda.atlassian.net/browse/PKG-15379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ