### PR TITLE
Rebuild against libxml2 2.15.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -4,6 +4,6 @@
 extra_labels_for_os:
   osx-arm64: [ventura]
 
-# Extend timeout to 6 hours (21600 seconds) for Windows builds
-task_timeout: 54600
+# Extend timeout to 12 hours (43200 seconds) for Windows builds
+task_timeout: 43200
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,4 +5,7 @@ extra_labels_for_os:
   osx-arm64: [ventura]
 
 # Extend timeout to 6 hours (21600 seconds) for Windows builds
-task_timeout: 21600
+task_timeout: 54600
+
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/libxml2-feedstock/pr29/eca1e3e

--- a/abs.yaml
+++ b/abs.yaml
@@ -7,5 +7,3 @@ extra_labels_for_os:
 # Extend timeout to 6 hours (21600 seconds) for Windows builds
 task_timeout: 54600
 
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/libxml2-feedstock/pr29/eca1e3e

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,3 +13,6 @@ cxx_compiler_version:
 
 c_stdlib_version:   # [win]
   - 2022.14         # [win]
+
+libxml2:
+  - 2.15.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,11 +34,11 @@ requirements:
     - ninja
     - python
     - libcxx-devel   # [osx]
-    - msys-sed        # [win]
-    - msys-grep       # [win]
-    - msys-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
-    - msys-diffutils  # [win]  # for cmp, diff
-    - msys-findutils  # [win]  # for find with -exec
+    - msys2-sed        # [win]
+    - msys2-grep       # [win]
+    - msys2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
+    - msys2-diffutils  # [win]  # for cmp, diff
+    - msys2-findutils  # [win]  # for find with -exec
     - git     # [not win]
   host:
     - backtrace {{ backtrace }}         # [unix]
@@ -63,7 +63,7 @@ outputs:
         - cmake
         - ninja
         - python
-        - msys-sed                  # [win]
+        - msys2-sed                  # [win]
         - libcxx-devel   # [osx]
       host:
         - libcxx-devel   # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/0008-win-skip-bb-hash-awk-test.patch  # [win]
 
 build:
-  number: 2
+  number: 3
   merge_build_host: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,11 +34,11 @@ requirements:
     - ninja
     - python
     - libcxx-devel   # [osx]
-    - m2-sed        # [win]
-    - m2-grep       # [win]
-    - m2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
-    - m2-diffutils  # [win]  # for cmp, diff
-    - m2-findutils  # [win]  # for find with -exec
+    - msys-sed        # [win]
+    - msys-grep       # [win]
+    - msys-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
+    - msys-diffutils  # [win]  # for cmp, diff
+    - msys-findutils  # [win]  # for find with -exec
     - git     # [not win]
   host:
     - backtrace {{ backtrace }}         # [unix]
@@ -63,7 +63,7 @@ outputs:
         - cmake
         - ninja
         - python
-        - m2-sed                  # [win]
+        - msys-sed                  # [win]
         - libcxx-devel   # [osx]
       host:
         - libcxx-devel   # [osx]


### PR DESCRIPTION
llvmdev 22.1.2

**Destination channel:**  defaults

### Links

- [PKG-15884](https://anaconda.atlassian.net/browse/PKG-15884) 
- [Upstream repository](https://github.com/llvm/llvm-project/tree/llvmorg-22.1.8)

### Explanation of changes:
- Rebuild against new version of libxml2 - 2.15.3


[PKG-15884]: https://anaconda.atlassian.net/browse/PKG-15884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ