### PR TITLE
Rebuild against libxml2 2.15.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - patches/0006-win-disable-orcjittests.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   merge_build_host: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,11 +32,11 @@ requirements:
     - ninja
     - python
     - libcxx-devel {{ version }}    # [osx]
-    - m2-sed        # [win]
-    - m2-grep       # [win]
-    - m2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
-    - m2-diffutils  # [win]  # for cmp, diff
-    - m2-findutils  # [win]  # for find with -exec
+    - msys2-sed        # [win]
+    - msys2-grep       # [win]
+    - msys2-coreutils  # [win]  # for cp, echo, head, tail, uniq, etc.
+    - msys2-diffutils  # [win]  # for cmp, diff
+    - msys2-findutils  # [win]  # for find with -exec
     - git
   host:
     - backtrace {{ backtrace }}         # [unix]
@@ -61,7 +61,7 @@ outputs:
         - cmake
         - ninja
         - python
-        - m2-sed                  # [win]
+        - msys2-sed                  # [win]
         - libcxx-devel {{ version }}  # [osx]
       host:
         - libcxx-devel {{ version }}  # [osx]


### PR DESCRIPTION
llvmdev 21.1.8
**Destination channel:** defaults

### Links

- [PKG-17027](https://anaconda.atlassian.net/browse/PKG-17027) 
- [Upstream repository](https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8)

### Explanation of changes:
- New build number


[PKG-17027]: https://anaconda.atlassian.net/browse/PKG-17027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ