### PR TITLE
Rebuild against libxml2 2.15.3 (fix)

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -17,5 +17,4 @@ c_stdlib_version:   # [win]
 # Required for PBP - not included in Python-variant task CBCs
 libffi:
   - '3.4'
-libxml2:
-  - 2.14.4
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - patches/0006-win-disable-orcjittests.patch  # [win]
 
 build:
-  number: 2
+  number: 3
   merge_build_host: false
 
 requirements:


### PR DESCRIPTION
llvmdev 21.1.8

**Destination channel:** defaults

### Links

- [PKG-17027](https://anaconda.atlassian.net/browse/PKG-17027) 
- [Upstream repository](https://github.com/llvm/llvm-project/tree/llvmorg-21.1.2)
### Explanation of changes:
- New build number
- Remove libxml2 2.14 from config file


[PKG-17027]: https://anaconda.atlassian.net/browse/PKG-17027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ